### PR TITLE
Indexer subscription: retry on 524 error

### DIFF
--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -378,7 +378,11 @@ func (c *restClient) GetEventStream(
 				}
 			}
 		}
-	}(ctx, eventsCh, chunkCh)
+	}(
+		ctx,
+		eventsCh,
+		chunkCh,
+	)
 
 	return eventsCh, cancel, nil
 }
@@ -500,7 +504,11 @@ func (c *restClient) GetTransactionsStream(
 				eventsCh <- event
 			}
 		}
-	}(ctx, eventsCh, chunkCh)
+	}(
+		ctx,
+		eventsCh,
+		chunkCh,
+	)
 
 	return eventsCh, cancel, nil
 }

--- a/indexer/rest/client.go
+++ b/indexer/rest/client.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
@@ -610,16 +609,6 @@ func listenToStream(url string, chunkCh chan chunk) {
 	for {
 		msg, err := reader.ReadBytes('\n')
 		if err != nil {
-			if strings.Contains(err.Error(), "524") {
-				fmt.Println("524 error, retrying")
-				resp, err = httpClient.Get(url)
-				if err != nil {
-					chunkCh <- chunk{err: err}
-					return
-				}
-				reader = bufio.NewReader(resp.Body)
-				continue
-			}
 			if err == io.EOF {
 				err = client.ErrConnectionClosedByServer
 			}

--- a/indexer/rest/client.go
+++ b/indexer/rest/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
@@ -600,6 +601,16 @@ func listenToStream(url string, chunkCh chan chunk) {
 	for {
 		msg, err := reader.ReadBytes('\n')
 		if err != nil {
+			if strings.Contains(err.Error(), "524") {
+				fmt.Println("524 error, retrying")
+				resp, err = httpClient.Get(url)
+				if err != nil {
+					chunkCh <- chunk{err: err}
+					return
+				}
+				reader = bufio.NewReader(resp.Body)
+				continue
+			}
 			if err == io.EOF {
 				err = client.ErrConnectionClosedByServer
 			}

--- a/indexer/rest/client.go
+++ b/indexer/rest/client.go
@@ -1,23 +1,19 @@
 package indexer
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
-	"github.com/arkade-os/go-sdk/client"
 	"github.com/arkade-os/go-sdk/indexer"
 	"github.com/arkade-os/go-sdk/indexer/rest/service/indexerservice"
 	"github.com/arkade-os/go-sdk/indexer/rest/service/indexerservice/indexer_service"
 	"github.com/arkade-os/go-sdk/indexer/rest/service/models"
+	"github.com/arkade-os/go-sdk/internal/utils"
 	"github.com/arkade-os/go-sdk/types"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
@@ -404,12 +400,12 @@ func (a *restClient) GetSubscription(
 ) (<-chan *indexer.ScriptEvent, func(), error) {
 	ctx, cancel := context.WithCancel(ctx)
 	eventsCh := make(chan *indexer.ScriptEvent)
-	chunkCh := make(chan chunk)
+	chunkCh := make(chan utils.ChunkJSONStream)
 	url := fmt.Sprintf("%s/v1/script/subscription/%s", a.serverURL, subscriptionId)
 
-	go listenToStream(url, chunkCh)
+	go utils.ListenToJSONStream(url, chunkCh)
 
-	go func(eventsCh chan *indexer.ScriptEvent, chunkCh chan chunk) {
+	go func(eventsCh chan *indexer.ScriptEvent, chunkCh chan utils.ChunkJSONStream) {
 		defer close(eventsCh)
 
 		for {
@@ -417,17 +413,17 @@ func (a *restClient) GetSubscription(
 			case <-ctx.Done():
 				return
 			case chunk := <-chunkCh:
-				if chunk.err == nil && len(chunk.msg) == 0 {
+				if chunk.Err == nil && len(chunk.Msg) == 0 {
 					continue
 				}
 
-				if chunk.err != nil {
-					eventsCh <- &indexer.ScriptEvent{Err: chunk.err}
+				if chunk.Err != nil {
+					eventsCh <- &indexer.ScriptEvent{Err: chunk.Err}
 					return
 				}
 
 				resp := indexer_service.IndexerServiceGetSubscriptionOKBody{}
-				if err := json.Unmarshal(chunk.msg, &resp); err != nil {
+				if err := json.Unmarshal(chunk.Msg, &resp); err != nil {
 					eventsCh <- &indexer.ScriptEvent{
 						Err: fmt.Errorf("failed to parse message from address stream: %s", err),
 					}
@@ -568,55 +564,6 @@ func parsePage(page *models.V1IndexerPageResponse) *indexer.PageResponse {
 		Current: page.Current,
 		Next:    page.Next,
 		Total:   page.Total,
-	}
-}
-
-type chunk struct {
-	msg []byte
-	err error
-}
-
-func listenToStream(url string, chunkCh chan chunk) {
-	defer close(chunkCh)
-
-	httpClient := &http.Client{Timeout: time.Second * 0}
-
-	var resp *http.Response
-
-	for resp == nil {
-		var err error
-		resp, err = httpClient.Get(url)
-		if err != nil {
-			chunkCh <- chunk{err: err}
-			return
-		}
-		// nolint:all
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			// handle 524 error by retrying
-			if resp.StatusCode == 524 {
-				resp = nil
-				continue
-			}
-
-			chunkCh <- chunk{err: fmt.Errorf("got unexpected status %d code", resp.StatusCode)}
-			return
-		}
-	}
-
-	reader := bufio.NewReader(resp.Body)
-	for {
-		msg, err := reader.ReadBytes('\n')
-		if err != nil {
-			if err == io.EOF {
-				err = client.ErrConnectionClosedByServer
-			}
-			chunkCh <- chunk{err: err}
-			return
-		}
-		msg = bytes.Trim(msg, "\n")
-		chunkCh <- chunk{msg: msg}
 	}
 }
 


### PR DESCRIPTION
This PR makes the gRPC and REST indexer clients "ignoring" 524 HTTP error status code.

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of event streaming by adding automatic retry logic for specific 524 errors in both gRPC and REST clients. The system now attempts to re-establish subscriptions or connections when these errors occur, reducing interruptions for users.
* **Refactor**
  * Centralized streaming JSON chunk reading logic into a shared utility, replacing local implementations for improved code reuse and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->