### PR TITLE
hotfix: keep track of batchId in settlement session

### DIFF
--- a/client.go
+++ b/client.go
@@ -1907,6 +1907,8 @@ func (a *arkClient) handleBatchEvents(
 	flatVtxoTree := make([]tree.TxTreeNode, 0)
 	flatConnectorTree := make([]tree.TxTreeNode, 0)
 
+	batchId := ""
+
 	var vtxoTree, connectorTree *tree.TxTree
 
 	if !hasOffchainOutput {
@@ -1930,8 +1932,6 @@ func (a *arkClient) handleBatchEvents(
 					replayEventsCh <- notify.Event
 				}()
 			}
-
-			batchId := ""
 
 			switch event := notify.Event; event.(type) {
 			case client.BatchStartedEvent:


### PR DESCRIPTION
The `batchId` var was misplaced, leading to ignore all incoming `BatchFailed` events.

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of batch identifiers during event processing for greater efficiency. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->