### PR TITLE
Abstract Batch session handlers

### DIFF
--- a/batch_session.go
+++ b/batch_session.go
@@ -1,0 +1,269 @@
+package arksdk
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
+	"github.com/arkade-os/go-sdk/client"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	start = iota
+	batchStarted
+	treeSigningStarted
+	treeNoncesAggregated
+	batchFinalization
+)
+
+type BatchEventHandlers interface {
+	OnBatchStarted(ctx context.Context, event client.BatchStartedEvent) (bool, error)
+	OnBatchFinalized(ctx context.Context, event client.BatchFinalizedEvent) error
+	OnBatchFailed(ctx context.Context, event client.BatchFailedEvent) error
+	OnTreeTxEvent(ctx context.Context, event client.TreeTxEvent) error
+	OnTreeSignatureEvent(ctx context.Context, event client.TreeSignatureEvent) error
+	OnTreeSigningStarted(ctx context.Context, event client.TreeSigningStartedEvent, vtxoTree *tree.TxTree) (bool, error)
+	OnTreeNoncesAggregated(ctx context.Context, event client.TreeNoncesAggregatedEvent) error
+	OnBatchFinalization(
+		ctx context.Context, event client.BatchFinalizationEvent,
+		vtxoTree *tree.TxTree, connectorTree *tree.TxTree,
+	) error
+}
+
+type options struct {
+	signVtxoTree   bool            // default: true
+	replayEventsCh chan<- any      // default: nil
+	cancelCh       <-chan struct{} // default: nil
+}
+
+func newOptions() *options {
+	return &options{
+		signVtxoTree:   true,
+		replayEventsCh: nil,
+		cancelCh:       nil,
+	}
+}
+
+type BatchSessionOption func(*options)
+
+func WithSkipVtxoTreeSigning() BatchSessionOption {
+	return func(o *options) {
+		o.signVtxoTree = false
+	}
+}
+
+func WithReplay(ch chan<- any) BatchSessionOption {
+	return func(o *options) {
+		o.replayEventsCh = ch
+	}
+}
+
+func WithCancel(cancelCh <-chan struct{}) BatchSessionOption {
+	return func(o *options) {
+		o.cancelCh = cancelCh
+	}
+}
+
+func HandleBatchEvents(
+	ctx context.Context,
+	eventsCh <-chan client.BatchEventChannel,
+	handlers BatchEventHandlers,
+	opts ...BatchSessionOption,
+) (string, error) {
+	options := newOptions()
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	step := start
+
+	// the txs of the tree are received one after the other via TxTreeEvent
+	// we collect them and then build the tree when necessary.
+	flatVtxoTree := make([]tree.TxTreeNode, 0)
+	flatConnectorTree := make([]tree.TxTreeNode, 0)
+
+	var vtxoTree, connectorTree *tree.TxTree
+
+	for {
+		select {
+		case <-options.cancelCh:
+			return "", fmt.Errorf("canceled")
+		case <-ctx.Done():
+			return "", fmt.Errorf("context done %s", ctx.Err())
+		case notify := <-eventsCh:
+			if notify.Err != nil {
+				return "", notify.Err
+			}
+
+			if options.replayEventsCh != nil {
+				go func() {
+					options.replayEventsCh <- notify.Event
+				}()
+			}
+
+			switch event := notify.Event; event.(type) {
+			case client.BatchStartedEvent:
+				e := event.(client.BatchStartedEvent)
+				skip, err := handlers.OnBatchStarted(ctx, e)
+				if err != nil {
+					return "", err
+				}
+				if !skip {
+					step++
+
+					// if we don't want to sign the vtxo tree, we can skip the tree signing phase
+					if !options.signVtxoTree {
+						step = treeNoncesAggregated
+					}
+					continue
+				}
+			case client.BatchFinalizedEvent:
+				if step != batchFinalization {
+					continue
+				}
+				event := event.(client.BatchFinalizedEvent)
+				if err := handlers.OnBatchFinalized(ctx, event); err != nil {
+					return "", err
+				}
+				return event.Txid, nil
+			// the batch session failed, return error only if we joined.
+			case client.BatchFailedEvent:
+				e := event.(client.BatchFailedEvent)
+				if err := handlers.OnBatchFailed(ctx, e); err != nil {
+					return "", err
+				}
+				continue
+			// we received a tree tx event msg, let's update the vtxo/connector tree.
+			case client.TreeTxEvent:
+				if step != batchStarted && step != treeNoncesAggregated {
+					continue
+				}
+
+				treeTxEvent := event.(client.TreeTxEvent)
+
+				if err := handlers.OnTreeTxEvent(ctx, treeTxEvent); err != nil {
+					return "", err
+				}
+
+				if treeTxEvent.BatchIndex == 0 {
+					flatVtxoTree = append(flatVtxoTree, treeTxEvent.Node)
+				} else {
+					flatConnectorTree = append(flatConnectorTree, treeTxEvent.Node)
+				}
+
+				continue
+			case client.TreeSignatureEvent:
+				if step != treeNoncesAggregated {
+					continue
+				}
+				if vtxoTree == nil {
+					return "", fmt.Errorf("vtxo tree not initialized")
+				}
+
+				event := event.(client.TreeSignatureEvent)
+				if err := handlers.OnTreeSignatureEvent(ctx, event); err != nil {
+					return "", err
+				}
+
+				if err := addSignatureToTxTree(event, vtxoTree); err != nil {
+					return "", err
+				}
+				continue
+			// the musig2 session started, let's send our nonces.
+			case client.TreeSigningStartedEvent:
+				if step != batchStarted {
+					continue
+				}
+
+				var err error
+				vtxoTree, err = tree.NewTxTree(flatVtxoTree)
+				if err != nil {
+					return "", fmt.Errorf("failed to create branch of vtxo tree: %s", err)
+				}
+
+				event := event.(client.TreeSigningStartedEvent)
+				skip, err := handlers.OnTreeSigningStarted(ctx, event, vtxoTree)
+				if err != nil {
+					return "", err
+				}
+
+				if !skip {
+					step++
+				}
+				continue
+			// we received the aggregated nonces, let's send our signatures.
+			case client.TreeNoncesAggregatedEvent:
+				if step != treeSigningStarted {
+					continue
+				}
+
+				event := event.(client.TreeNoncesAggregatedEvent)
+				if err := handlers.OnTreeNoncesAggregated(ctx, event); err != nil {
+					return "", err
+				}
+
+				step++
+				continue
+			// we received the fully signed vtxo and connector trees, let's send our signed forfeit
+			// txs and optionally signed boarding utxos included in the commitment tx.
+			case client.BatchFinalizationEvent:
+				if step != treeNoncesAggregated {
+					continue
+				}
+
+				if vtxoTree == nil {
+					return "", fmt.Errorf("vtxo tree not initialized")
+				}
+
+				if len(flatConnectorTree) > 0 {
+					var err error
+					connectorTree, err = tree.NewTxTree(flatConnectorTree)
+					if err != nil {
+						return "", fmt.Errorf("failed to create branch of connector tree: %s", err)
+					}
+				}
+
+				event := event.(client.BatchFinalizationEvent)
+				if err := handlers.OnBatchFinalization(ctx, event, vtxoTree, connectorTree); err != nil {
+					return "", err
+				}
+
+				log.Info("done.")
+				log.Info("waiting for batch finalization...")
+				step++
+				continue
+			}
+		}
+	}
+}
+
+func addSignatureToTxTree(
+	event client.TreeSignatureEvent, txTree *tree.TxTree,
+) error {
+	if event.BatchIndex != 0 {
+		return fmt.Errorf("batch index %d is not 0", event.BatchIndex)
+	}
+
+	decodedSig, err := hex.DecodeString(event.Signature)
+	if err != nil {
+		return fmt.Errorf("failed to decode signature: %s", err)
+	}
+
+	sig, err := schnorr.ParseSignature(decodedSig)
+	if err != nil {
+		return fmt.Errorf("failed to parse signature: %s", err)
+	}
+
+	return txTree.Apply(func(g *tree.TxTree) (bool, error) {
+		if g.Root.UnsignedTx.TxID() != event.Txid {
+			return true, nil
+		}
+
+		g.Root.Inputs[0].TaprootKeySpendSig = sig.Serialize()
+		return false, nil
+	})
+}

--- a/batch_session.go
+++ b/batch_session.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
 	"github.com/arkade-os/go-sdk/client"
+	"github.com/arkade-os/go-sdk/types"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	log "github.com/sirupsen/logrus"
 )
@@ -18,6 +19,17 @@ const (
 	treeNoncesAggregated
 	batchFinalization
 )
+
+func GetEventStreamTopics(
+	spentOutpoints []types.Outpoint,
+	signerPublicKeys []string,
+) []string {
+	topics := make([]string, 0, len(spentOutpoints)+len(signerPublicKeys))
+	for _, outpoint := range spentOutpoints {
+		topics = append(topics, outpoint.String())
+	}
+	return append(topics, signerPublicKeys...)
+}
 
 type BatchEventHandlers interface {
 	OnBatchStarted(ctx context.Context, event client.BatchStartedEvent) (bool, error)

--- a/client.go
+++ b/client.go
@@ -2753,6 +2753,7 @@ func (h *batchHandlers) OnTreeSigningStarted(ctx context.Context, event client.T
 	}
 
 	if len(foundPubkeys) <= 0 {
+		log.Info("no signer found in cosigner list, waiting for next one...")
 		return true, nil
 	}
 

--- a/client.go
+++ b/client.go
@@ -1852,6 +1852,29 @@ func (a *arkClient) joinBatchWithRetry(
 	return "", fmt.Errorf("reached max atttempt of retries, last batch error: %s", batchErr)
 }
 
+func (a *arkClient) newBatchHandlers(
+	intentId string, vtxos []client.TapscriptsVtxo, boardingUtxos []types.Utxo, receivers []types.Receiver, signerSessions []tree.SignerSession,
+) *batchHandlers {
+	// exclude recoverable vtxos as they don't need any signing step
+	vtxosToSign := make([]client.TapscriptsVtxo, 0)
+	for _, vtxo := range vtxos {
+		if !vtxo.IsRecoverable() {
+			// recoverable vtxos don't need to sign a forfeit tx
+			vtxosToSign = append(vtxosToSign, vtxo)
+		}
+	}
+
+	return &batchHandlers{
+		arkClient:      a,
+		intentId:       intentId,
+		vtxos:          vtxosToSign,
+		boardingUtxos:  boardingUtxos,
+		receivers:      receivers,
+		signerSessions: signerSessions,
+		cacheBatchId:   "",
+	}
+}
+
 func (a *arkClient) handleBatchEvents(
 	ctx context.Context,
 	intentId string, vtxos []client.TapscriptsVtxo, boardingUtxos []types.Utxo,
@@ -1866,6 +1889,27 @@ func (a *arkClient) handleBatchEvents(
 		topics = append(topics, signer.GetPublicKey())
 	}
 
+	handlers := a.newBatchHandlers(intentId, vtxos, boardingUtxos, receivers, signerSessions)
+
+	// skip if there is no offchain output
+	skipVtxoTreeSigning := false
+	for _, receiver := range receivers {
+		if _, err := arklib.DecodeAddressV0(receiver.To); err == nil {
+			skipVtxoTreeSigning = true
+			break
+		}
+	}
+
+	options := []BatchSessionOption{WithCancel(cancelCh)}
+
+	if skipVtxoTreeSigning {
+		options = append(options, WithSkipVtxoTreeSigning())
+	}
+
+	if replayEventsCh != nil {
+		options = append(options, WithReplay(replayEventsCh))
+	}
+
 	eventsCh, close, err := a.client.GetEventStream(ctx, topics)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
@@ -1875,727 +1919,13 @@ func (a *arkClient) handleBatchEvents(
 		return "", err
 	}
 
-	vtxosToSign := make([]client.TapscriptsVtxo, 0)
-	for _, vtxo := range vtxos {
-		if !vtxo.IsRecoverable() {
-			// recoverable vtxos don't need to sign a forfeit tx
-			vtxosToSign = append(vtxosToSign, vtxo)
-		}
-	}
-
-	const (
-		start = iota
-		batchStarted
-		treeSigningStarted
-		treeNoncesAggregated
-		batchFinalization
-	)
-
-	step := start
-	hasOffchainOutput := false
-	for _, receiver := range receivers {
-		if _, err := arklib.DecodeAddressV0(receiver.To); err == nil {
-			hasOffchainOutput = true
-			break
-		}
-	}
-
-	// the txs of the tree are received one after the other via TxTreeEvent
-	// we collect them and then build the tree when necessary.
-	flatVtxoTree := make([]tree.TxTreeNode, 0)
-	flatConnectorTree := make([]tree.TxTreeNode, 0)
-
-	var vtxoTree, connectorTree *tree.TxTree
-
-	if !hasOffchainOutput {
-		// if none of the outputs are offchain, we should skip the vtxo tree signing steps
-		step = treeNoncesAggregated
-	}
-
-	for {
-		select {
-		case <-cancelCh:
-			return "", fmt.Errorf("canceled")
-		case <-ctx.Done():
-			return "", fmt.Errorf("context done %s", ctx.Err())
-		case notify := <-eventsCh:
-			if notify.Err != nil {
-				return "", notify.Err
-			}
-
-			if replayEventsCh != nil {
-				go func() {
-					replayEventsCh <- notify.Event
-				}()
-			}
-
-			batchId := ""
-
-			switch event := notify.Event; event.(type) {
-			case client.BatchStartedEvent:
-				e := event.(client.BatchStartedEvent)
-				skipped, err := a.handleBatchStarted(ctx, intentId, e)
-				if err != nil {
-					return "", err
-				}
-				if !skipped {
-					batchId = event.(client.BatchStartedEvent).Id
-					log.Infof("batch started %s, participation confirmed", batchId)
-					step++
-
-					if !hasOffchainOutput {
-						// if none of the outputs are offchain, we should skip tree signing phase
-						step = treeNoncesAggregated
-					}
-					continue
-				}
-				log.Info("intent id not found in batch proposal, waiting for next one...")
-			case client.BatchFinalizedEvent:
-				if step != batchFinalization {
-					continue
-				}
-				txid := event.(client.BatchFinalizedEvent).Txid
-				log.Infof("batch completed in commitment tx %s", txid)
-				return event.(client.BatchFinalizedEvent).Txid, nil
-			// the batch session failed, return error only if we joined.
-			case client.BatchFailedEvent:
-				e := event.(client.BatchFailedEvent)
-				if e.Id == batchId {
-					return "", fmt.Errorf("batch failed: %s", e.Reason)
-				}
-				continue
-			// we received a tree tx event msg, let's update the vtxo/connector tree.
-			case client.TreeTxEvent:
-				if step != batchStarted && step != treeNoncesAggregated {
-					continue
-				}
-
-				treeTxEvent := event.(client.TreeTxEvent)
-
-				if treeTxEvent.BatchIndex == 0 {
-					flatVtxoTree = append(flatVtxoTree, treeTxEvent.Node)
-				} else {
-					flatConnectorTree = append(flatConnectorTree, treeTxEvent.Node)
-				}
-				continue
-			case client.TreeSignatureEvent:
-				if step != treeNoncesAggregated {
-					continue
-				}
-				if vtxoTree == nil {
-					return "", fmt.Errorf("vtxo tree not initialized")
-				}
-
-				if err := handleBatchTreeSignature(event.(client.TreeSignatureEvent), vtxoTree); err != nil {
-					return "", err
-				}
-				continue
-			// the musig2 session started, let's send our nonces.
-			case client.TreeSigningStartedEvent:
-				if step != batchStarted {
-					continue
-				}
-				vtxoTree, err = tree.NewTxTree(flatVtxoTree)
-				if err != nil {
-					return "", fmt.Errorf("failed to create branch of vtxo tree: %s", err)
-				}
-
-				log.Info("tree signing session started, sending nonces...")
-				skipped, err := a.handleTreeSigningStarted(
-					ctx, signerSessions, event.(client.TreeSigningStartedEvent), vtxoTree,
-				)
-				if err != nil {
-					return "", err
-				}
-				if !skipped {
-					step++
-				}
-				continue
-			// we received the aggregated nonces, let's send our signatures.
-			case client.TreeNoncesAggregatedEvent:
-				if step != treeSigningStarted {
-					continue
-				}
-				log.Info("tree nonces aggregated, sending signatures...")
-				if err := a.handleTreeNoncesAggregated(
-					ctx, event.(client.TreeNoncesAggregatedEvent), signerSessions,
-				); err != nil {
-					return "", err
-				}
-				step++
-				continue
-			// we received the fully signed vtxo and connector trees, let's send our signed forfeit
-			// txs and optionally signed boarding utxos included in the commitment tx.
-			case client.BatchFinalizationEvent:
-				if step != treeNoncesAggregated {
-					continue
-				}
-				log.Info("vtxo and connector trees fully signed, sending forfeit transactions...")
-
-				if vtxoTree == nil {
-					return "", fmt.Errorf("vtxo tree not initialized")
-				}
-
-				if len(flatConnectorTree) > 0 {
-					connectorTree, err = tree.NewTxTree(flatConnectorTree)
-					if err != nil {
-						return "", fmt.Errorf("failed to create branch of connector tree: %s", err)
-					}
-				}
-
-				if len(vtxosToSign) > 0 && connectorTree == nil {
-					return "", fmt.Errorf("connectors tree not sent")
-				}
-
-				signedForfeitTxs, signedCommitmentTx, err := a.handleBatchFinalization(
-					ctx, event.(client.BatchFinalizationEvent),
-					vtxosToSign, boardingUtxos, receivers,
-					vtxoTree, connectorTree,
-				)
-				if err != nil {
-					return "", err
-				}
-
-				if len(signedForfeitTxs) > 0 || len(signedCommitmentTx) > 0 {
-					if err := a.client.SubmitSignedForfeitTxs(
-						ctx, signedForfeitTxs, signedCommitmentTx,
-					); err != nil {
-						return "", err
-					}
-				}
-
-				log.Info("done.")
-				log.Info("waiting for batch finalization...")
-				step++
-				continue
-			}
-		}
-	}
-}
-
-func (a *arkClient) handleBatchStarted(
-	ctx context.Context, intentId string, event client.BatchStartedEvent,
-) (bool, error) {
-	buf := sha256.Sum256([]byte(intentId))
-	hashedIntentId := hex.EncodeToString(buf[:])
-
-	for _, hash := range event.HashedIntentIds {
-		if hash == hashedIntentId {
-			if err := a.client.ConfirmRegistration(ctx, intentId); err != nil {
-				return false, err
-			}
-			return false, nil
-		}
-	}
-
-	return true, nil
-}
-
-func (a *arkClient) handleTreeSigningStarted(
-	ctx context.Context, signerSessions []tree.SignerSession,
-	event client.TreeSigningStartedEvent, vtxoTree *tree.TxTree,
-) (bool, error) {
-	foundPubkeys := make([]string, 0, len(signerSessions))
-	for _, session := range signerSessions {
-		myPubkey := session.GetPublicKey()
-		for _, cosigner := range event.CosignersPubkeys {
-			if cosigner == myPubkey {
-				foundPubkeys = append(foundPubkeys, myPubkey)
-				break
-			}
-		}
-	}
-
-	if len(foundPubkeys) <= 0 {
-		return true, nil
-	}
-
-	if len(foundPubkeys) != len(signerSessions) {
-		return false, fmt.Errorf("not all signers found in cosigner list")
-	}
-
-	sweepClosure := script.CSVMultisigClosure{
-		MultisigClosure: script.MultisigClosure{PubKeys: []*secp256k1.PublicKey{a.SignerPubKey}},
-		Locktime:        a.VtxoTreeExpiry,
-	}
-
-	script, err := sweepClosure.Script()
+	commitmentTxid, err := HandleBatchEvents(ctx, eventsCh, handlers, options...)
 	if err != nil {
-		return false, err
+		close()
+		return "", err
 	}
 
-	commitmentTx, err := psbt.NewFromRawBytes(strings.NewReader(event.UnsignedCommitmentTx), true)
-	if err != nil {
-		return false, err
-	}
-
-	batchOutput := commitmentTx.UnsignedTx.TxOut[0]
-	batchOutputAmount := batchOutput.Value
-
-	sweepTapLeaf := txscript.NewBaseTapLeaf(script)
-	sweepTapTree := txscript.AssembleTaprootScriptTree(sweepTapLeaf)
-	root := sweepTapTree.RootNode.TapHash()
-
-	generateAndSendNonces := func(session tree.SignerSession) error {
-		if err := session.Init(root.CloneBytes(), batchOutputAmount, vtxoTree); err != nil {
-			return err
-		}
-
-		nonces, err := session.GetNonces()
-		if err != nil {
-			return err
-		}
-
-		return a.client.SubmitTreeNonces(ctx, event.Id, session.GetPublicKey(), nonces)
-	}
-
-	errChan := make(chan error, len(signerSessions))
-	waitGroup := sync.WaitGroup{}
-	waitGroup.Add(len(signerSessions))
-
-	for _, session := range signerSessions {
-		go func(session tree.SignerSession) {
-			defer waitGroup.Done()
-			if err := generateAndSendNonces(session); err != nil {
-				errChan <- err
-			}
-		}(session)
-	}
-
-	waitGroup.Wait()
-
-	close(errChan)
-
-	for err := range errChan {
-		if err != nil {
-			return false, err
-		}
-	}
-
-	return false, nil
-}
-
-func (a *arkClient) handleTreeNoncesAggregated(
-	ctx context.Context,
-	event client.TreeNoncesAggregatedEvent, signerSessions []tree.SignerSession,
-) error {
-	if len(signerSessions) <= 0 {
-		return fmt.Errorf("tree signer session not set")
-	}
-
-	sign := func(session tree.SignerSession) error {
-		session.SetAggregatedNonces(event.Nonces)
-
-		sigs, err := session.Sign()
-		if err != nil {
-			return err
-		}
-
-		return a.client.SubmitTreeSignatures(
-			ctx,
-			event.Id,
-			session.GetPublicKey(),
-			sigs,
-		)
-	}
-
-	errChan := make(chan error, len(signerSessions))
-	waitGroup := sync.WaitGroup{}
-	waitGroup.Add(len(signerSessions))
-
-	for _, session := range signerSessions {
-		go func(session tree.SignerSession) {
-			defer waitGroup.Done()
-			if err := sign(session); err != nil {
-				errChan <- err
-			}
-		}(session)
-	}
-
-	waitGroup.Wait()
-	close(errChan)
-
-	for err := range errChan {
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (a *arkClient) handleBatchFinalization(
-	ctx context.Context,
-	event client.BatchFinalizationEvent, vtxos []client.TapscriptsVtxo, boardingUtxos []types.Utxo,
-	receivers []types.Receiver, vtxoTree, connectorTree *tree.TxTree,
-) ([]string, string, error) {
-	if err := a.validateVtxoTree(event, vtxoTree, connectorTree, receivers, vtxos); err != nil {
-		return nil, "", fmt.Errorf("failed to verify vtxo tree: %s", err)
-	}
-
-	var forfeits []string
-
-	if len(vtxos) > 0 {
-		signedForfeits, err := a.createAndSignForfeits(
-			ctx,
-			vtxos, connectorTree.Leaves(),
-		)
-		if err != nil {
-			return nil, "", err
-		}
-
-		forfeits = signedForfeits
-	}
-
-	if len(boardingUtxos) <= 0 {
-		return forfeits, "", nil
-	}
-
-	// if we have boarding inputs, we must sign the commitment transaction too.
-	commitmentPtx, err := psbt.NewFromRawBytes(strings.NewReader(event.Tx), true)
-	if err != nil {
-		return nil, "", err
-	}
-
-	for _, boardingUtxo := range boardingUtxos {
-		boardingVtxoScript, err := script.ParseVtxoScript(boardingUtxo.Tapscripts)
-		if err != nil {
-			return nil, "", err
-		}
-
-		forfeitClosures := boardingVtxoScript.ForfeitClosures()
-		if len(forfeitClosures) <= 0 {
-			return nil, "", fmt.Errorf("no forfeit closures found")
-		}
-
-		forfeitClosure := forfeitClosures[0]
-
-		forfeitScript, err := forfeitClosure.Script()
-		if err != nil {
-			return nil, "", err
-		}
-
-		_, taprootTree, err := boardingVtxoScript.TapTree()
-		if err != nil {
-			return nil, "", err
-		}
-
-		forfeitLeaf := txscript.NewBaseTapLeaf(forfeitScript)
-		forfeitProof, err := taprootTree.GetTaprootMerkleProof(forfeitLeaf.TapHash())
-		if err != nil {
-			return nil, "", fmt.Errorf(
-				"failed to get taproot merkle proof for boarding utxo: %s", err,
-			)
-		}
-
-		tapscript := &psbt.TaprootTapLeafScript{
-			ControlBlock: forfeitProof.ControlBlock,
-			Script:       forfeitProof.Script,
-			LeafVersion:  txscript.BaseLeafVersion,
-		}
-
-		for i := range commitmentPtx.Inputs {
-			prevout := commitmentPtx.UnsignedTx.TxIn[i].PreviousOutPoint
-
-			if boardingUtxo.Txid == prevout.Hash.String() && boardingUtxo.VOut == prevout.Index {
-				commitmentPtx.Inputs[i].TaprootLeafScript = []*psbt.TaprootTapLeafScript{tapscript}
-				break
-			}
-		}
-	}
-
-	b64, err := commitmentPtx.B64Encode()
-	if err != nil {
-		return nil, "", err
-	}
-
-	signedCommitmentTx, err := a.wallet.SignTransaction(ctx, a.explorer, b64)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return forfeits, signedCommitmentTx, nil
-}
-
-func (a *arkClient) validateVtxoTree(
-	event client.BatchFinalizationEvent,
-	vtxoTree, connectorTree *tree.TxTree,
-	receivers []types.Receiver, vtxosInput []client.TapscriptsVtxo,
-) error {
-	commitmentTx := event.Tx
-	commitmentPtx, err := psbt.NewFromRawBytes(strings.NewReader(commitmentTx), true)
-	if err != nil {
-		return err
-	}
-
-	// validate the vtxo tree is well formed
-	if !utils.IsOnchainOnly(receivers) {
-		if err := tree.ValidateVtxoTree(
-			vtxoTree, commitmentPtx, a.SignerPubKey, a.VtxoTreeExpiry,
-		); err != nil {
-			return err
-		}
-	}
-
-	// validate it contains our outputs
-	if err := a.validateReceivers(
-		commitmentPtx, receivers, vtxoTree,
-	); err != nil {
-		return err
-	}
-
-	if len(vtxosInput) > 0 {
-		rootParentTxid := vtxoTree.Root.UnsignedTx.TxIn[0].PreviousOutPoint.Hash.String()
-		rootParentVout := vtxoTree.Root.UnsignedTx.TxIn[0].PreviousOutPoint.Index
-
-		if rootParentTxid != commitmentPtx.UnsignedTx.TxID() {
-			return fmt.Errorf(
-				"root's parent txid is not the same as the commitment txid: %s != %s",
-				rootParentTxid,
-				commitmentPtx.UnsignedTx.TxID(),
-			)
-		}
-
-		if rootParentVout != 0 {
-			return fmt.Errorf(
-				"root's parent vout is not the same as the shared output index: %d != %d",
-				rootParentVout,
-				0,
-			)
-		}
-
-		if err := connectorTree.Validate(); err != nil {
-			return err
-		}
-
-		connectorsLeaves := connectorTree.Leaves()
-		if len(connectorsLeaves) != len(vtxosInput) {
-			return fmt.Errorf(
-				"unexpected num of connectors received: expected %d, got %d",
-				len(vtxosInput),
-				len(connectorsLeaves),
-			)
-		}
-	}
-
-	return nil
-}
-
-func (a *arkClient) validateReceivers(
-	ptx *psbt.Packet, receivers []types.Receiver, vtxoTree *tree.TxTree,
-) error {
-	netParams := utils.ToBitcoinNetwork(a.Network)
-	for _, receiver := range receivers {
-		isOnChain, onchainScript, err := utils.ParseBitcoinAddress(receiver.To, netParams)
-		if err != nil {
-			return fmt.Errorf("invalid receiver address: %s err = %s", receiver.To, err)
-		}
-
-		if isOnChain {
-			if err := a.validateOnchainReceiver(ptx, receiver, onchainScript); err != nil {
-				return err
-			}
-		} else {
-			if err := a.validateOffchainReceiver(vtxoTree, receiver); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func (a *arkClient) validateOnchainReceiver(
-	ptx *psbt.Packet, receiver types.Receiver, onchainScript []byte,
-) error {
-	found := false
-	for _, output := range ptx.UnsignedTx.TxOut {
-		if bytes.Equal(output.PkScript, onchainScript) {
-			if output.Value != int64(receiver.Amount) {
-				return fmt.Errorf(
-					"invalid collaborative exit output amount: got %d, want %d",
-					output.Value, receiver.Amount,
-				)
-			}
-			found = true
-			break
-		}
-	}
-	if !found {
-		return fmt.Errorf("collaborative exit output not found: %s", receiver.To)
-	}
-	return nil
-}
-
-func (a *arkClient) validateOffchainReceiver(
-	vtxoTree *tree.TxTree, receiver types.Receiver,
-) error {
-	found := false
-
-	rcvAddr, err := arklib.DecodeAddressV0(receiver.To)
-	if err != nil {
-		return err
-	}
-
-	vtxoTapKey := schnorr.SerializePubKey(rcvAddr.VtxoTapKey)
-
-	leaves := vtxoTree.Leaves()
-	for _, leaf := range leaves {
-		for _, output := range leaf.UnsignedTx.TxOut {
-			if len(output.PkScript) == 0 {
-				continue
-			}
-
-			if bytes.Equal(output.PkScript[2:], vtxoTapKey) {
-				if output.Value != int64(receiver.Amount) {
-					continue
-				}
-
-				found = true
-				break
-			}
-		}
-
-		if found {
-			break
-		}
-	}
-
-	if !found {
-		return fmt.Errorf("offchain send output not found: %s", receiver.To)
-	}
-
-	return nil
-}
-
-func (a *arkClient) createAndSignForfeits(
-	ctx context.Context,
-	vtxosToSign []client.TapscriptsVtxo,
-	connectorsLeaves []*psbt.Packet,
-) ([]string, error) {
-	parsedForfeitAddr, err := btcutil.DecodeAddress(a.ForfeitAddress, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	forfeitPkScript, err := txscript.PayToAddrScript(parsedForfeitAddr)
-	if err != nil {
-		return nil, err
-	}
-
-	signedForfeitTxs := make([]string, 0, len(vtxosToSign))
-	for i, vtxo := range vtxosToSign {
-		connectorTx := connectorsLeaves[i]
-
-		var connector *wire.TxOut
-		var connectorOutpoint *wire.OutPoint
-		for outIndex, output := range connectorTx.UnsignedTx.TxOut {
-			if bytes.Equal(txutils.ANCHOR_PKSCRIPT, output.PkScript) {
-				continue
-			}
-
-			connector = output
-			connectorOutpoint = &wire.OutPoint{
-				Hash:  connectorTx.UnsignedTx.TxHash(),
-				Index: uint32(outIndex),
-			}
-			break
-		}
-
-		if connector == nil {
-			return nil, fmt.Errorf("connector not found for vtxo %s", vtxo.Outpoint.String())
-		}
-
-		vtxoScript, err := script.ParseVtxoScript(vtxo.Tapscripts)
-		if err != nil {
-			return nil, err
-		}
-
-		vtxoTapKey, vtxoTapTree, err := vtxoScript.TapTree()
-		if err != nil {
-			return nil, err
-		}
-
-		vtxoOutputScript, err := script.P2TRScript(vtxoTapKey)
-		if err != nil {
-			return nil, err
-		}
-
-		vtxoTxHash, err := chainhash.NewHashFromStr(vtxo.Txid)
-		if err != nil {
-			return nil, err
-		}
-
-		vtxoInput := &wire.OutPoint{
-			Hash:  *vtxoTxHash,
-			Index: vtxo.VOut,
-		}
-
-		forfeitClosures := vtxoScript.ForfeitClosures()
-		if len(forfeitClosures) <= 0 {
-			return nil, fmt.Errorf("no forfeit closures found")
-		}
-
-		forfeitClosure := forfeitClosures[0]
-
-		forfeitScript, err := forfeitClosure.Script()
-		if err != nil {
-			return nil, err
-		}
-
-		forfeitLeaf := txscript.NewBaseTapLeaf(forfeitScript)
-		leafProof, err := vtxoTapTree.GetTaprootMerkleProof(forfeitLeaf.TapHash())
-		if err != nil {
-			return nil, err
-		}
-
-		tapscript := psbt.TaprootTapLeafScript{
-			ControlBlock: leafProof.ControlBlock,
-			Script:       leafProof.Script,
-			LeafVersion:  txscript.BaseLeafVersion,
-		}
-
-		vtxoLocktime := arklib.AbsoluteLocktime(0)
-		if cltv, ok := forfeitClosure.(*script.CLTVMultisigClosure); ok {
-			vtxoLocktime = cltv.Locktime
-		}
-
-		vtxoPrevout := &wire.TxOut{
-			Value:    int64(vtxo.Amount),
-			PkScript: vtxoOutputScript,
-		}
-
-		vtxoSequence := wire.MaxTxInSequenceNum
-		if vtxoLocktime != 0 {
-			vtxoSequence = wire.MaxTxInSequenceNum - 1
-		}
-
-		forfeitTx, err := tree.BuildForfeitTx(
-			[]*wire.OutPoint{vtxoInput, connectorOutpoint},
-			[]uint32{vtxoSequence, wire.MaxTxInSequenceNum},
-			[]*wire.TxOut{vtxoPrevout, connector},
-			forfeitPkScript,
-			uint32(vtxoLocktime),
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		forfeitTx.Inputs[0].TaprootLeafScript = []*psbt.TaprootTapLeafScript{&tapscript}
-
-		b64, err := forfeitTx.B64Encode()
-		if err != nil {
-			return nil, err
-		}
-
-		signedForfeitTx, err := a.wallet.SignTransaction(ctx, a.explorer, b64)
-		if err != nil {
-			return nil, err
-		}
-
-		signedForfeitTxs = append(signedForfeitTxs, signedForfeitTx)
-	}
-
-	return signedForfeitTxs, nil
+	return commitmentTxid, nil
 }
 
 func (a *arkClient) getMatureUtxos(ctx context.Context) ([]types.Utxo, error) {
@@ -3358,4 +2688,560 @@ func (i *arkClient) vtxosToTxs(
 	}
 
 	return txs, nil
+}
+
+type batchHandlers struct {
+	*arkClient
+
+	intentId       string
+	vtxos          []client.TapscriptsVtxo
+	boardingUtxos  []types.Utxo
+	receivers      []types.Receiver
+	signerSessions []tree.SignerSession
+
+	cacheBatchId string
+}
+
+func (h *batchHandlers) OnBatchStarted(ctx context.Context, event client.BatchStartedEvent) (bool, error) {
+	buf := sha256.Sum256([]byte(h.intentId))
+	hashedIntentId := hex.EncodeToString(buf[:])
+
+	for _, hash := range event.HashedIntentIds {
+		if hash == hashedIntentId {
+			if err := h.client.ConfirmRegistration(ctx, h.intentId); err != nil {
+				return false, err
+			}
+			h.cacheBatchId = event.Id
+			return false, nil
+		}
+	}
+
+	log.Info("intent id not found in batch proposal, waiting for next one...")
+	return true, nil
+}
+
+func (h *batchHandlers) OnBatchFinalized(ctx context.Context, event client.BatchFinalizedEvent) error {
+	log.Infof("batch completed in commitment tx %s", event.Txid)
+	return nil
+}
+
+func (h *batchHandlers) OnBatchFailed(ctx context.Context, event client.BatchFailedEvent) error {
+	if event.Id == h.cacheBatchId {
+		return fmt.Errorf("batch failed: %s", event.Reason)
+	}
+	return nil
+}
+
+func (h *batchHandlers) OnTreeTxEvent(ctx context.Context, event client.TreeTxEvent) error {
+	return nil
+}
+
+func (h *batchHandlers) OnTreeSignatureEvent(ctx context.Context, event client.TreeSignatureEvent) error {
+	return nil
+}
+
+func (h *batchHandlers) OnTreeSigningStarted(ctx context.Context, event client.TreeSigningStartedEvent, vtxoTree *tree.TxTree) (bool, error) {
+	foundPubkeys := make([]string, 0, len(h.signerSessions))
+	for _, session := range h.signerSessions {
+		myPubkey := session.GetPublicKey()
+		for _, cosigner := range event.CosignersPubkeys {
+			if cosigner == myPubkey {
+				foundPubkeys = append(foundPubkeys, myPubkey)
+				break
+			}
+		}
+	}
+
+	if len(foundPubkeys) <= 0 {
+		return true, nil
+	}
+
+	if len(foundPubkeys) != len(h.signerSessions) {
+		return false, fmt.Errorf("not all signers found in cosigner list")
+	}
+
+	sweepClosure := script.CSVMultisigClosure{
+		MultisigClosure: script.MultisigClosure{PubKeys: []*secp256k1.PublicKey{h.SignerPubKey}},
+		Locktime:        h.VtxoTreeExpiry,
+	}
+
+	script, err := sweepClosure.Script()
+	if err != nil {
+		return false, err
+	}
+
+	commitmentTx, err := psbt.NewFromRawBytes(strings.NewReader(event.UnsignedCommitmentTx), true)
+	if err != nil {
+		return false, err
+	}
+
+	batchOutput := commitmentTx.UnsignedTx.TxOut[0]
+	batchOutputAmount := batchOutput.Value
+
+	sweepTapLeaf := txscript.NewBaseTapLeaf(script)
+	sweepTapTree := txscript.AssembleTaprootScriptTree(sweepTapLeaf)
+	root := sweepTapTree.RootNode.TapHash()
+
+	generateAndSendNonces := func(session tree.SignerSession) error {
+		if err := session.Init(root.CloneBytes(), batchOutputAmount, vtxoTree); err != nil {
+			return err
+		}
+
+		nonces, err := session.GetNonces()
+		if err != nil {
+			return err
+		}
+
+		return h.client.SubmitTreeNonces(ctx, event.Id, session.GetPublicKey(), nonces)
+	}
+
+	errChan := make(chan error, len(h.signerSessions))
+	waitGroup := sync.WaitGroup{}
+	waitGroup.Add(len(h.signerSessions))
+
+	for _, session := range h.signerSessions {
+		go func(session tree.SignerSession) {
+			defer waitGroup.Done()
+			if err := generateAndSendNonces(session); err != nil {
+				errChan <- err
+			}
+		}(session)
+	}
+
+	waitGroup.Wait()
+
+	close(errChan)
+
+	for err := range errChan {
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return false, nil
+}
+
+func (h *batchHandlers) OnTreeNoncesAggregated(ctx context.Context, event client.TreeNoncesAggregatedEvent) error {
+	log.Info("tree nonces aggregated, sending signatures...")
+	if len(h.signerSessions) <= 0 {
+		return fmt.Errorf("tree signer session not set")
+	}
+
+	sign := func(session tree.SignerSession) error {
+		session.SetAggregatedNonces(event.Nonces)
+
+		sigs, err := session.Sign()
+		if err != nil {
+			return err
+		}
+
+		return h.client.SubmitTreeSignatures(
+			ctx,
+			event.Id,
+			session.GetPublicKey(),
+			sigs,
+		)
+	}
+
+	errChan := make(chan error, len(h.signerSessions))
+	waitGroup := sync.WaitGroup{}
+	waitGroup.Add(len(h.signerSessions))
+
+	for _, session := range h.signerSessions {
+		go func(session tree.SignerSession) {
+			defer waitGroup.Done()
+			if err := sign(session); err != nil {
+				errChan <- err
+			}
+		}(session)
+	}
+
+	waitGroup.Wait()
+	close(errChan)
+
+	for err := range errChan {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *batchHandlers) OnBatchFinalization(ctx context.Context, event client.BatchFinalizationEvent, vtxoTree *tree.TxTree, connectorTree *tree.TxTree) error {
+	log.Info("vtxo and connector trees fully signed, sending forfeit transactions...")
+	if err := h.validateVtxoTree(event, vtxoTree, connectorTree); err != nil {
+		return fmt.Errorf("failed to verify vtxo tree: %s", err)
+	}
+
+	var forfeits []string
+
+	if len(h.vtxos) > 0 {
+		signedForfeits, err := h.createAndSignForfeits(
+			ctx,
+			h.vtxos, connectorTree.Leaves(),
+		)
+		if err != nil {
+			return err
+		}
+
+		forfeits = signedForfeits
+	}
+
+	if len(h.boardingUtxos) <= 0 {
+		return nil
+	}
+
+	// if we have boarding inputs, we must sign the commitment transaction too.
+	commitmentPtx, err := psbt.NewFromRawBytes(strings.NewReader(event.Tx), true)
+	if err != nil {
+		return err
+	}
+
+	for _, boardingUtxo := range h.boardingUtxos {
+		boardingVtxoScript, err := script.ParseVtxoScript(boardingUtxo.Tapscripts)
+		if err != nil {
+			return err
+		}
+
+		forfeitClosures := boardingVtxoScript.ForfeitClosures()
+		if len(forfeitClosures) <= 0 {
+			return fmt.Errorf("no forfeit closures found")
+		}
+
+		forfeitClosure := forfeitClosures[0]
+
+		forfeitScript, err := forfeitClosure.Script()
+		if err != nil {
+			return err
+		}
+
+		_, taprootTree, err := boardingVtxoScript.TapTree()
+		if err != nil {
+			return err
+		}
+
+		forfeitLeaf := txscript.NewBaseTapLeaf(forfeitScript)
+		forfeitProof, err := taprootTree.GetTaprootMerkleProof(forfeitLeaf.TapHash())
+		if err != nil {
+			return fmt.Errorf(
+				"failed to get taproot merkle proof for boarding utxo: %s", err,
+			)
+		}
+
+		tapscript := &psbt.TaprootTapLeafScript{
+			ControlBlock: forfeitProof.ControlBlock,
+			Script:       forfeitProof.Script,
+			LeafVersion:  txscript.BaseLeafVersion,
+		}
+
+		for i := range commitmentPtx.Inputs {
+			prevout := commitmentPtx.UnsignedTx.TxIn[i].PreviousOutPoint
+
+			if boardingUtxo.Txid == prevout.Hash.String() && boardingUtxo.VOut == prevout.Index {
+				commitmentPtx.Inputs[i].TaprootLeafScript = []*psbt.TaprootTapLeafScript{tapscript}
+				break
+			}
+		}
+	}
+
+	b64, err := commitmentPtx.B64Encode()
+	if err != nil {
+		return err
+	}
+
+	signedCommitmentTx, err := h.wallet.SignTransaction(ctx, h.explorer, b64)
+	if err != nil {
+		return err
+	}
+
+	if len(forfeits) > 0 || len(signedCommitmentTx) > 0 {
+		if err := h.client.SubmitSignedForfeitTxs(
+			ctx, forfeits, signedCommitmentTx,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *batchHandlers) validateVtxoTree(
+	event client.BatchFinalizationEvent,
+	vtxoTree, connectorTree *tree.TxTree,
+) error {
+	commitmentTx := event.Tx
+	commitmentPtx, err := psbt.NewFromRawBytes(strings.NewReader(commitmentTx), true)
+	if err != nil {
+		return err
+	}
+
+	// validate the vtxo tree is well formed
+	if !utils.IsOnchainOnly(h.receivers) {
+		if err := tree.ValidateVtxoTree(
+			vtxoTree, commitmentPtx, h.SignerPubKey, h.VtxoTreeExpiry,
+		); err != nil {
+			return err
+		}
+	}
+
+	// validate it contains our outputs
+	if err := validateReceivers(
+		h.Network, commitmentPtx, h.receivers, vtxoTree,
+	); err != nil {
+		return err
+	}
+
+	if len(h.vtxos) > 0 {
+		rootParentTxid := vtxoTree.Root.UnsignedTx.TxIn[0].PreviousOutPoint.Hash.String()
+		rootParentVout := vtxoTree.Root.UnsignedTx.TxIn[0].PreviousOutPoint.Index
+
+		if rootParentTxid != commitmentPtx.UnsignedTx.TxID() {
+			return fmt.Errorf(
+				"root's parent txid is not the same as the commitment txid: %s != %s",
+				rootParentTxid,
+				commitmentPtx.UnsignedTx.TxID(),
+			)
+		}
+
+		if rootParentVout != 0 {
+			return fmt.Errorf(
+				"root's parent vout is not the same as the shared output index: %d != %d",
+				rootParentVout,
+				0,
+			)
+		}
+
+		if err := connectorTree.Validate(); err != nil {
+			return err
+		}
+
+		connectorsLeaves := connectorTree.Leaves()
+		if len(connectorsLeaves) != len(h.vtxos) {
+			return fmt.Errorf(
+				"unexpected num of connectors received: expected %d, got %d",
+				len(h.vtxos),
+				len(connectorsLeaves),
+			)
+		}
+	}
+
+	return nil
+}
+
+func (h *batchHandlers) createAndSignForfeits(
+	ctx context.Context,
+	vtxosToSign []client.TapscriptsVtxo,
+	connectorsLeaves []*psbt.Packet,
+) ([]string, error) {
+	parsedForfeitAddr, err := btcutil.DecodeAddress(h.ForfeitAddress, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	forfeitPkScript, err := txscript.PayToAddrScript(parsedForfeitAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	signedForfeitTxs := make([]string, 0, len(vtxosToSign))
+	for i, vtxo := range vtxosToSign {
+		connectorTx := connectorsLeaves[i]
+
+		var connector *wire.TxOut
+		var connectorOutpoint *wire.OutPoint
+		for outIndex, output := range connectorTx.UnsignedTx.TxOut {
+			if bytes.Equal(txutils.ANCHOR_PKSCRIPT, output.PkScript) {
+				continue
+			}
+
+			connector = output
+			connectorOutpoint = &wire.OutPoint{
+				Hash:  connectorTx.UnsignedTx.TxHash(),
+				Index: uint32(outIndex),
+			}
+			break
+		}
+
+		if connector == nil {
+			return nil, fmt.Errorf("connector not found for vtxo %s", vtxo.Outpoint.String())
+		}
+
+		vtxoScript, err := script.ParseVtxoScript(vtxo.Tapscripts)
+		if err != nil {
+			return nil, err
+		}
+
+		vtxoTapKey, vtxoTapTree, err := vtxoScript.TapTree()
+		if err != nil {
+			return nil, err
+		}
+
+		vtxoOutputScript, err := script.P2TRScript(vtxoTapKey)
+		if err != nil {
+			return nil, err
+		}
+
+		vtxoTxHash, err := chainhash.NewHashFromStr(vtxo.Txid)
+		if err != nil {
+			return nil, err
+		}
+
+		vtxoInput := &wire.OutPoint{
+			Hash:  *vtxoTxHash,
+			Index: vtxo.VOut,
+		}
+
+		forfeitClosures := vtxoScript.ForfeitClosures()
+		if len(forfeitClosures) <= 0 {
+			return nil, fmt.Errorf("no forfeit closures found")
+		}
+
+		forfeitClosure := forfeitClosures[0]
+
+		forfeitScript, err := forfeitClosure.Script()
+		if err != nil {
+			return nil, err
+		}
+
+		forfeitLeaf := txscript.NewBaseTapLeaf(forfeitScript)
+		leafProof, err := vtxoTapTree.GetTaprootMerkleProof(forfeitLeaf.TapHash())
+		if err != nil {
+			return nil, err
+		}
+
+		tapscript := psbt.TaprootTapLeafScript{
+			ControlBlock: leafProof.ControlBlock,
+			Script:       leafProof.Script,
+			LeafVersion:  txscript.BaseLeafVersion,
+		}
+
+		vtxoLocktime := arklib.AbsoluteLocktime(0)
+		if cltv, ok := forfeitClosure.(*script.CLTVMultisigClosure); ok {
+			vtxoLocktime = cltv.Locktime
+		}
+
+		vtxoPrevout := &wire.TxOut{
+			Value:    int64(vtxo.Amount),
+			PkScript: vtxoOutputScript,
+		}
+
+		vtxoSequence := wire.MaxTxInSequenceNum
+		if vtxoLocktime != 0 {
+			vtxoSequence = wire.MaxTxInSequenceNum - 1
+		}
+
+		forfeitTx, err := tree.BuildForfeitTx(
+			[]*wire.OutPoint{vtxoInput, connectorOutpoint},
+			[]uint32{vtxoSequence, wire.MaxTxInSequenceNum},
+			[]*wire.TxOut{vtxoPrevout, connector},
+			forfeitPkScript,
+			uint32(vtxoLocktime),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		forfeitTx.Inputs[0].TaprootLeafScript = []*psbt.TaprootTapLeafScript{&tapscript}
+
+		b64, err := forfeitTx.B64Encode()
+		if err != nil {
+			return nil, err
+		}
+
+		signedForfeitTx, err := h.wallet.SignTransaction(ctx, h.explorer, b64)
+		if err != nil {
+			return nil, err
+		}
+
+		signedForfeitTxs = append(signedForfeitTxs, signedForfeitTx)
+	}
+
+	return signedForfeitTxs, nil
+}
+
+func validateReceivers(
+	network arklib.Network, ptx *psbt.Packet, receivers []types.Receiver, vtxoTree *tree.TxTree,
+) error {
+	netParams := utils.ToBitcoinNetwork(network)
+	for _, receiver := range receivers {
+		isOnChain, onchainScript, err := utils.ParseBitcoinAddress(receiver.To, netParams)
+		if err != nil {
+			return fmt.Errorf("invalid receiver address: %s err = %s", receiver.To, err)
+		}
+
+		if isOnChain {
+			if err := validateOnchainReceiver(ptx, receiver, onchainScript); err != nil {
+				return err
+			}
+		} else {
+			if err := validateOffchainReceiver(vtxoTree, receiver); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateOnchainReceiver(
+	ptx *psbt.Packet, receiver types.Receiver, onchainScript []byte,
+) error {
+	found := false
+	for _, output := range ptx.UnsignedTx.TxOut {
+		if bytes.Equal(output.PkScript, onchainScript) {
+			if output.Value != int64(receiver.Amount) {
+				return fmt.Errorf(
+					"invalid collaborative exit output amount: got %d, want %d",
+					output.Value, receiver.Amount,
+				)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("collaborative exit output not found: %s", receiver.To)
+	}
+	return nil
+}
+
+func validateOffchainReceiver(
+	vtxoTree *tree.TxTree, receiver types.Receiver,
+) error {
+	found := false
+
+	rcvAddr, err := arklib.DecodeAddressV0(receiver.To)
+	if err != nil {
+		return err
+	}
+
+	vtxoTapKey := schnorr.SerializePubKey(rcvAddr.VtxoTapKey)
+
+	leaves := vtxoTree.Leaves()
+	for _, leaf := range leaves {
+		for _, output := range leaf.UnsignedTx.TxOut {
+			if len(output.PkScript) == 0 {
+				continue
+			}
+
+			if bytes.Equal(output.PkScript[2:], vtxoTapKey) {
+				if output.Value != int64(receiver.Amount) {
+					continue
+				}
+
+				found = true
+				break
+			}
+		}
+
+		if found {
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("offchain send output not found: %s", receiver.To)
+	}
+
+	return nil
 }

--- a/client.go
+++ b/client.go
@@ -1893,11 +1893,12 @@ func (a *arkClient) handleBatchEvents(
 
 	handlers := a.newBatchHandlers(intentId, vtxos, boardingUtxos, receivers, signerSessions)
 
-	// skip if there is no offchain output
-	skipVtxoTreeSigning := false
+	// skip only if there is no offchain output
+	skipVtxoTreeSigning := true
+
 	for _, receiver := range receivers {
 		if _, err := arklib.DecodeAddressV0(receiver.To); err == nil {
-			skipVtxoTreeSigning = true
+			skipVtxoTreeSigning = false
 			break
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.1
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 
 require (
-	github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-20250708155328-721172a83dba
+	github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-20250721121631-e1e43e311796
 	github.com/btcsuite/btcd v0.24.3-0.20240921052913-67b8efd3ba53
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.5

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.1
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 
 require (
-	github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-20250721121631-e1e43e311796
+	github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-20250808095756-159449132a3b
 	github.com/btcsuite/btcd v0.24.3-0.20240921052913-67b8efd3ba53
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmH
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-20250721121631-e1e43e311796 h1:RkLMOnTHl6KFmAp50nDgnO2QTUgKWsBIEtnBySiRdsE=
-github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-20250721121631-e1e43e311796/go.mod h1:HbVpJ+RYvfCfMvzKyhEau+CVRqH0fz034dzTKb5RXgA=
+github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-20250808095756-159449132a3b h1:pAgwJpAPIP1r2KAFGEWlR6Nb+wULOqfrlNEve0+kCvU=
+github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-20250808095756-159449132a3b/go.mod h1:HbVpJ+RYvfCfMvzKyhEau+CVRqH0fz034dzTKb5RXgA=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmH
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-20250708155328-721172a83dba h1:lBg7yeTZoaClwv30sLfur3bzn1/NPuUbz/xoQnbhLiI=
-github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-20250708155328-721172a83dba/go.mod h1:HbVpJ+RYvfCfMvzKyhEau+CVRqH0fz034dzTKb5RXgA=
+github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-20250721121631-e1e43e311796 h1:RkLMOnTHl6KFmAp50nDgnO2QTUgKWsBIEtnBySiRdsE=
+github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-20250721121631-e1e43e311796/go.mod h1:HbVpJ+RYvfCfMvzKyhEau+CVRqH0fz034dzTKb5RXgA=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/utils.go
+++ b/utils.go
@@ -17,11 +17,9 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/note"
 	"github.com/arkade-os/arkd/pkg/ark-lib/offchain"
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
-	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
 	"github.com/arkade-os/arkd/pkg/ark-lib/txutils"
 	"github.com/arkade-os/go-sdk/client"
 	"github.com/arkade-os/go-sdk/types"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
@@ -435,33 +433,6 @@ func finalizeWithNotes(notesWitnesses map[int][]byte) func(ptx *psbt.Packet) err
 
 		return nil
 	}
-}
-
-func handleBatchTreeSignature(
-	event client.TreeSignatureEvent, txTree *tree.TxTree,
-) error {
-	if event.BatchIndex != 0 {
-		return fmt.Errorf("batch index %d is not 0", event.BatchIndex)
-	}
-
-	decodedSig, err := hex.DecodeString(event.Signature)
-	if err != nil {
-		return fmt.Errorf("failed to decode signature: %s", err)
-	}
-
-	sig, err := schnorr.ParseSignature(decodedSig)
-	if err != nil {
-		return fmt.Errorf("failed to parse signature: %s", err)
-	}
-
-	return txTree.Apply(func(g *tree.TxTree) (bool, error) {
-		if g.Root.UnsignedTx.TxID() != event.Txid {
-			return true, nil
-		}
-
-		g.Root.Inputs[0].TaprootKeySpendSig = sig.Serialize()
-		return false, nil
-	})
 }
 
 func checkSettleOptionsType(o interface{}) (*SettleOptions, error) {

--- a/wallet/singlekey/bitcoin_wallet.go
+++ b/wallet/singlekey/bitcoin_wallet.go
@@ -198,10 +198,6 @@ func (s *bitcoinWallet) SignTransaction(
 		if err := updater.AddInWitnessUtxo(utxo, i); err != nil {
 			return "", err
 		}
-
-		if err := updater.AddInSighashType(txscript.SigHashDefault, i); err != nil {
-			return "", err
-		}
 	}
 
 	prevouts := make(map[wire.OutPoint]*wire.TxOut)
@@ -305,15 +301,11 @@ func (w *bitcoinWallet) signTapscriptSpend(
 		}
 
 		if sign {
-			if err := updater.AddInSighashType(txscript.SigHashDefault, inputIndex); err != nil {
-				return err
-			}
-
 			hash := txscript.NewTapLeaf(leaf.LeafVersion, leaf.Script).TapHash()
 
 			preimage, err := txscript.CalcTapscriptSignaturehash(
 				txsighashes,
-				txscript.SigHashDefault,
+				input.SighashType,
 				updater.Upsbt.UnsignedTx,
 				inputIndex,
 				prevoutFetcher,
@@ -341,7 +333,7 @@ func (w *bitcoinWallet) signTapscriptSpend(
 					XOnlyPubKey: myPubkey,
 					LeafHash:    hash.CloneBytes(),
 					Signature:   sig.Serialize(),
-					SigHash:     txscript.SigHashDefault,
+					SigHash:     input.SighashType,
 				},
 			)
 		}
@@ -370,7 +362,7 @@ func (w *bitcoinWallet) signTaprootKeySpend(
 
 	preimage, err := txscript.CalcTaprootSignatureHash(
 		txsighashes,
-		txscript.SigHashDefault,
+		input.SighashType,
 		updater.Upsbt.UnsignedTx,
 		inputIndex,
 		prevoutFetcher,


### PR DESCRIPTION
This PR aims to detach the batch session event handlers from wallet to a dedicated `HandleBatchEvents` function.

The wallet uses this abstraction with "default" handlers implementing the regular session flow, but it allows writing custom batch session flow using the SDK.

@Kukks @altafan @tiero please review
