### PR TITLE
update to go1.24.6

### DIFF
--- a/.github/workflows/autogen_client.yaml
+++ b/.github/workflows/autogen_client.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.1'
+          go-version: '>=1.24.6'
 
       - name: Install deps
         run: go mod download

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.1'
+          go-version: '>=1.24.6'
 
       - run: go mod tidy
 

--- a/arkd.Dockerfile
+++ b/arkd.Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.23.1 AS builder
+FROM golang:1.24.6 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/arkdwallet.Dockerfile
+++ b/arkdwallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet-daemon binary
-FROM golang:1.23.1 AS builder
+FROM golang:1.24.6 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/go-sdk
 
-go 1.23.1
+go 1.24.6
 
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 


### PR DESCRIPTION
fix vulnerability https://www.cve.org/CVERecord/SearchResults?query=CVE-2025-47907

https://github.com/arkade-os/arkd/pull/681

@altafan @Kukks  please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded the Go toolchain to 1.24.6 across build environments and tooling.
  - Rebuilt service and wallet container images using the newer Go version for improved compatibility, performance, and security posture.
  - No user-facing functionality changes are expected; behavior should remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->