### PR TITLE
Validation offchain transactions signatures

### DIFF
--- a/client.go
+++ b/client.go
@@ -3125,6 +3125,22 @@ func verifyOffchainPsbt(original, signed *psbt.Packet, signerpubkey *btcec.Publi
 		return fmt.Errorf("invalid offchain tx : txids mismatch")
 	}
 
+	if len(original.Inputs) != len(signed.Inputs) {
+		return fmt.Errorf(
+			"input count mismatch: expected %d, got %d",
+			len(original.Inputs),
+			len(signed.Inputs),
+		)
+	}
+
+	if len(original.UnsignedTx.TxIn) != len(signed.UnsignedTx.TxIn) {
+		return fmt.Errorf(
+			"transaction input count mismatch: expected %d, got %d",
+			len(original.UnsignedTx.TxIn),
+			len(signed.UnsignedTx.TxIn),
+		)
+	}
+
 	prevouts := make(map[wire.OutPoint]*wire.TxOut)
 
 	for inputIndex, signedInput := range signed.Inputs {


### PR DESCRIPTION
This PR adds validation on the signed ark and checkpoins transactions received from the server after SubmitTx

Before finalizing the offchain transaction, the client does : 
* verify the tx contains the signer's signature
* validate signature
* check tx integrity

@altafan @aruokhai please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added cryptographic verification for server-signed off-chain transactions and checkpoint data to validate transaction integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->