### PR TITLE
Handle arkd info digest

### DIFF
--- a/base_client.go
+++ b/base_client.go
@@ -486,6 +486,7 @@ func (a *arkClient) initWithWallet(ctx context.Context, args InitWithWalletArgs)
 		VtxoMaxAmount:                info.VtxoMaxAmount,
 		CheckpointTapscript:          info.CheckpointTapscript,
 		Fees:                         info.Fees,
+		InfoDigest:                   info.Digest,
 	}
 	if err := a.store.ConfigStore().AddData(ctx, storeData); err != nil {
 		return err
@@ -590,6 +591,7 @@ func (a *arkClient) init(ctx context.Context, args InitArgs) error {
 		VtxoMaxAmount:                info.VtxoMaxAmount,
 		CheckpointTapscript:          info.CheckpointTapscript,
 		Fees:                         info.Fees,
+		InfoDigest:                   info.Digest,
 	}
 	walletSvc, err := getWallet(a.store.ConfigStore(), &cfgData, supportedWallets)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -3,7 +3,9 @@ package arksdk
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -19,6 +21,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
 	"github.com/arkade-os/arkd/pkg/ark-lib/txutils"
+	arkv1 "github.com/arkade-os/go-sdk/api-spec/protobuf/gen/ark/v1"
 	"github.com/arkade-os/go-sdk/client"
 	"github.com/arkade-os/go-sdk/explorer"
 	mempool_explorer "github.com/arkade-os/go-sdk/explorer/mempool"
@@ -70,7 +73,8 @@ func LoadArkClient(sdkStore types.Store, opts ...ClientOption) (ArkClient, error
 		return nil, fmt.Errorf("missing sdk repository")
 	}
 
-	cfgData, err := sdkStore.ConfigStore().GetData(context.Background())
+	ctx := context.Background()
+	cfgData, err := sdkStore.ConfigStore().GetData(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -78,11 +82,32 @@ func LoadArkClient(sdkStore types.Store, opts ...ClientOption) (ArkClient, error
 		return nil, ErrNotInitialized
 	}
 
+	// compute the digest if not already set in the config
+	if len(cfgData.InfoDigest) == 0 {
+		infoDigest, err := computeDigest(cfgData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute info digest: %s", err)
+		}
+		cfgData.InfoDigest = infoDigest
+		if err := sdkStore.ConfigStore().AddData(ctx, *cfgData); err != nil {
+			return nil, fmt.Errorf("failed to add info digest to config: %s", err)
+		}
+	}
+
 	clientSvc, err := getClient(
 		supportedClients, cfgData.ClientType, cfgData.ServerUrl,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup transport client: %s", err)
+	}
+
+	info, err := clientSvc.GetInfo(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get info: %s", err)
+	}
+
+	if info.Digest != cfgData.InfoDigest {
+		return nil, DigestMismatchError{Expected: info.Digest, Actual: cfgData.InfoDigest}
 	}
 
 	explorerOpts := []mempool_explorer.Option{
@@ -140,7 +165,9 @@ func LoadArkClientWithWallet(
 		return nil, fmt.Errorf("missin wallet service")
 	}
 
-	cfgData, err := sdkStore.ConfigStore().GetData(context.Background())
+	ctx := context.Background()
+
+	cfgData, err := sdkStore.ConfigStore().GetData(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -148,11 +175,32 @@ func LoadArkClientWithWallet(
 		return nil, ErrNotInitialized
 	}
 
+	// compute the digest if not already set in the config
+	if len(cfgData.InfoDigest) == 0 {
+		infoDigest, err := computeDigest(cfgData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute info digest: %s", err)
+		}
+		cfgData.InfoDigest = infoDigest
+		if err := sdkStore.ConfigStore().AddData(ctx, *cfgData); err != nil {
+			return nil, fmt.Errorf("failed to add info digest to config: %s", err)
+		}
+	}
+
 	clientSvc, err := getClient(
 		supportedClients, cfgData.ClientType, cfgData.ServerUrl,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup transport client: %s", err)
+	}
+
+	info, err := clientSvc.GetInfo(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get info: %s", err)
+	}
+
+	if info.Digest != cfgData.InfoDigest {
+		return nil, DigestMismatchError{Expected: info.Digest, Actual: cfgData.InfoDigest}
 	}
 
 	explorerOpts := []mempool_explorer.Option{
@@ -3259,4 +3307,30 @@ func verifyOffchainPsbt(original, signed *psbt.Packet, signerpubkey *btcec.Publi
 		}
 	}
 	return nil
+}
+
+func computeDigest(cfgData *types.Config) (string, error) {
+	resp := &arkv1.GetInfoResponse{
+		SignerPubkey:        hex.EncodeToString(cfgData.SignerPubKey.SerializeCompressed()),
+		ForfeitPubkey:       hex.EncodeToString(cfgData.ForfeitPubKey.SerializeCompressed()),
+		UnilateralExitDelay: int64(cfgData.UnilateralExitDelay.Value),
+		BoardingExitDelay:   int64(cfgData.BoardingExitDelay.Value),
+		SessionDuration:     cfgData.SessionDuration,
+		Network:             cfgData.Network.Name,
+		Dust:                int64(cfgData.Dust),
+		ForfeitAddress:      cfgData.ForfeitAddress,
+		// Version:             cfgData.Version, // TODO : add version to config ? remove from digest ?
+		UtxoMinAmount:       cfgData.UtxoMinAmount,
+		UtxoMaxAmount:       cfgData.UtxoMaxAmount,
+		VtxoMinAmount:       cfgData.VtxoMinAmount,
+		VtxoMaxAmount:       cfgData.VtxoMaxAmount,
+		CheckpointTapscript: cfgData.CheckpointTapscript,
+	}
+	buf, err := json.Marshal(resp)
+	if err != nil {
+		return "", err
+	}
+
+	digest := sha256.Sum256(buf)
+	return hex.EncodeToString(digest[:]), nil
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,14 @@
+package arksdk
+
+import (
+	"fmt"
+)
+
+type DigestMismatchError struct {
+	Expected string
+	Actual   string
+}
+
+func (e DigestMismatchError) Error() string {
+	return fmt.Sprintf("arkd info digest mismatch: expected %s, actual %s", e.Expected, e.Actual)
+}

--- a/store/file/config_store.go
+++ b/store/file/config_store.go
@@ -73,6 +73,7 @@ func (s *configStore) AddData(ctx context.Context, data types.Config) error {
 		VtxoMinAmount:       fmt.Sprintf("%d", data.VtxoMinAmount),
 		VtxoMaxAmount:       fmt.Sprintf("%d", data.VtxoMaxAmount),
 		CheckpointTapscript: data.CheckpointTapscript,
+		InfoDigest:          data.InfoDigest,
 		Fees: feeData{
 			TxFeeRate: fmt.Sprintf("%.1f", data.Fees.TxFeeRate),
 			IntentFees: intentFeeData{

--- a/store/file/types.go
+++ b/store/file/types.go
@@ -44,6 +44,7 @@ type storeData struct {
 	VtxoMaxAmount                string  `json:"vtxo_max_amount"`
 	CheckpointTapscript          string  `json:"checkpoint_tapscript"`
 	Fees                         feeData `json:"fees"`
+	InfoDigest                   string  `json:"info_digest"`
 }
 
 func (d storeData) isEmpty() bool {
@@ -124,6 +125,7 @@ func (d storeData) decode() types.Config {
 		VtxoMaxAmount:                int64(vtxoMaxAmount),
 		CheckpointTapscript:          d.CheckpointTapscript,
 		Fees:                         fees,
+		InfoDigest:                   d.InfoDigest,
 	}
 }
 
@@ -148,6 +150,7 @@ func (d storeData) asMap() map[string]any {
 		"vtxo_min_amount":        d.VtxoMinAmount,
 		"vtxo_max_amount":        d.VtxoMaxAmount,
 		"checkpoint_tapscript":   d.CheckpointTapscript,
+		"info_digest":            d.InfoDigest,
 		"fees": map[string]any{
 			"tx_fee_rate": d.Fees.TxFeeRate,
 			"intent_fees": map[string]string{

--- a/store/service_test.go
+++ b/store/service_test.go
@@ -31,6 +31,7 @@ var (
 		BoardingExitDelay:   arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 512},
 		ForfeitAddress:      "bcrt1qzvqj",
 		CheckpointTapscript: "abcdefghijklmnopqrtuvxyz",
+		InfoDigest:          "test-info-digest",
 	}
 
 	testUtxos = []types.Utxo{

--- a/types/types.go
+++ b/types/types.go
@@ -43,6 +43,7 @@ type Config struct {
 	VtxoMaxAmount                int64
 	CheckpointTapscript          string
 	Fees                         FeeInfo
+	InfoDigest                   string
 }
 
 func (c Config) CheckpointExitPath() []byte {

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -31,7 +31,8 @@ func TestWallet(t *testing.T) {
 		Dust:                1000,
 		BoardingExitDelay:   arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 512},
 		ForfeitAddress:      "bcrt1qzvqj",
-		CheckpointTapscript: "",
+		CheckpointTapscript: "5120039201234567890123456789012345678901234567890123456789012345",
+		InfoDigest:          "test-info-digest",
 	}
 	tests := []struct {
 		name  string


### PR DESCRIPTION
This PR updates ConfigStore to persist the digest and call /info endpoint on load. It fails with `DigestMismatchError` in case the server's digest differs from the store one.

DRAFT because we need to figure out the digest computation

@altafan @Kukks please review