### PR TITLE
Bump golang@v1.25.6

### DIFF
--- a/.github/workflows/autogen_client.yaml
+++ b/.github/workflows/autogen_client.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.5
+          go-version: 1.25.6
 
       - name: Install deps
         run: go mod download

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '>=1.25.5'
+          go-version: '>=1.25.6'
       
       - run: go mod tidy
       

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '>=1.25.5'
+          go-version: '>=1.25.6'
 
       - run: go mod tidy
 

--- a/arkd.Dockerfile
+++ b/arkd.Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.25.5 AS builder
+FROM golang:1.25.6 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/arkdwallet.Dockerfile
+++ b/arkdwallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet-daemon binary
-FROM golang:1.25.5 AS builder
+FROM golang:1.25.6 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/go-sdk
 
-go 1.25.5
+go 1.25.6
 
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 

--- a/test/docker/server.Dockerfile
+++ b/test/docker/server.Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.25.5 AS builder
+FROM golang:1.25.6 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/test/docker/wallet.Dockerfile
+++ b/test/docker/wallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet-daemon binary
-FROM golang:1.25.5 AS builder
+FROM golang:1.25.6 AS builder
 
 ARG VERSION
 ARG TARGETOS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.25.6 across build configurations and development environments for improved consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->