### PR TITLE
Bump go-sdk@02f7156c

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v
 
 require (
 	github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260323091657-eeb0baef6937
-	github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260323091657-eeb0baef6937
+	github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260326144949-02f7156cda43
 	github.com/btcsuite/btcd v0.24.3-0.20240921052913-67b8efd3ba53
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5
 	github.com/btcsuite/btcd/btcutil v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/arkade-os/arkd/api-spec v0.0.0-20260323091657-eeb0baef6937 h1:010LTrh
 github.com/arkade-os/arkd/api-spec v0.0.0-20260323091657-eeb0baef6937/go.mod h1:2+6ix1UGGE22Q/rbab1dycFPPKiTyq0gldKVqVfFPWs=
 github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260323091657-eeb0baef6937 h1:1r8NojJwAR/Q5hanPW0PzYJrhjZU5620HRAIqs+rItQ=
 github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260323091657-eeb0baef6937/go.mod h1:P5ipJ1CatvH6xKxEtMUt4KhUGl1JPLcFiSdo1PGTny8=
-github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260323091657-eeb0baef6937 h1:13Dhh7RBSfVCB/JpupTNPpFdwVz08g4i1iNRzZTR6rE=
-github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260323091657-eeb0baef6937/go.mod h1:Y59cvCug7rHWjERYKbbrjStn4+vXGmWu5LOqLggf7Aw=
+github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260326144949-02f7156cda43 h1:1PXyHEMRPjWV5KplyZHXWXRsrq9GOaEcuDd7+FEmMOw=
+github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260326144949-02f7156cda43/go.mod h1:Y59cvCug7rHWjERYKbbrjStn4+vXGmWu5LOqLggf7Aw=
 github.com/arkade-os/arkd/pkg/errors v0.0.0-20260303153651-8615412e4dea h1:x9ZwZL+F2b9E0uBZYBVjCLGtlqIE4zahDOY4C89h3X4=
 github.com/arkade-os/arkd/pkg/errors v0.0.0-20260303153651-8615412e4dea/go.mod h1:NYGE+baj57ynbXNwjISJddMDpMqAWOX27dV22xqFm2A=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=


### PR DESCRIPTION
Bumping deps fixes a regression on batch session methods (Settle, CollaborativeExit), now only vtxos close to (custom) expiration are included.

Please @sekulicd review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to maintain system stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->