### PR TITLE
Add ValidateAddress function to check onchain and offchain addresses

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -141,6 +141,31 @@ func getVtxo(usedVtxos []types.Vtxo, spentByVtxos []types.Vtxo) types.Vtxo {
 	return types.Vtxo{}
 }
 
+// ValidateAddress checks whether address is a valid Bitcoin onchain address or
+// a valid Ark offchain address. The network is inferred from the address prefix
+// so no client configuration is required.
+// Returns (true, false, nil) for a valid onchain address,
+// (false, true, nil) for a valid offchain address, or
+// (false, false, error) if the address is invalid.
+func ValidateAddress(address string) (isOnchain bool, isOffchain bool, err error) {
+	knownNetworks := []*chaincfg.Params{
+		&chaincfg.MainNetParams,
+		&chaincfg.TestNet3Params,
+		&chaincfg.SigNetParams,
+		&chaincfg.RegressionNetParams,
+		&arklib.MutinyNetSigNetParams,
+	}
+	for _, net := range knownNetworks {
+		if _, e := btcutil.DecodeAddress(address, net); e == nil {
+			return true, false, nil
+		}
+	}
+	if _, e := arklib.DecodeAddressV0(address); e == nil {
+		return false, true, nil
+	}
+	return false, false, fmt.Errorf("invalid address: %s", address)
+}
+
 func toOutputScript(onchainAddress string, network arklib.Network) ([]byte, error) {
 	netParams := toBitcoinNetwork(network)
 	rcvAddr, err := btcutil.DecodeAddress(onchainAddress, &netParams)

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,11 +2,19 @@ package arksdk_test
 
 import (
 	"context"
+	"testing"
 
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
 	"github.com/arkade-os/arkd/pkg/client-lib/explorer"
 	clienttypes "github.com/arkade-os/arkd/pkg/client-lib/types"
 	"github.com/arkade-os/arkd/pkg/client-lib/wallet"
+	arksdk "github.com/arkade-os/go-sdk"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
 )
 
 type mockWallet struct{}
@@ -56,4 +64,85 @@ func (m *mockWallet) Dump(_ context.Context) (string, error) {
 }
 func (m *mockWallet) NewVtxoTreeSigner(_ context.Context, _ string) (tree.SignerSession, error) {
 	return nil, nil
+}
+
+func TestValidateAddress(t *testing.T) {
+	// Generate keys once for constructing addresses programmatically.
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	pubKey := privKey.PubKey()
+	pubKeyHash := btcutil.Hash160(pubKey.SerializeCompressed())
+
+	// Onchain addresses across different networks and script types.
+	p2pkhMainnet, err := btcutil.NewAddressPubKeyHash(pubKeyHash, &chaincfg.MainNetParams)
+	require.NoError(t, err)
+	p2wpkhMainnet, err := btcutil.NewAddressWitnessPubKeyHash(pubKeyHash, &chaincfg.MainNetParams)
+	require.NoError(t, err)
+	p2trMainnet, err := btcutil.NewAddressTaproot(schnorr.SerializePubKey(pubKey), &chaincfg.MainNetParams)
+	require.NoError(t, err)
+	p2pkhTestnet, err := btcutil.NewAddressPubKeyHash(pubKeyHash, &chaincfg.TestNet3Params)
+	require.NoError(t, err)
+	p2trRegtest, err := btcutil.NewAddressTaproot(schnorr.SerializePubKey(pubKey), &chaincfg.RegressionNetParams)
+	require.NoError(t, err)
+
+	// Offchain Ark address (tark = Bitcoin testnet HRP).
+	signerKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	arkAddr := arklib.Address{
+		Version:    0,
+		HRP:        arklib.BitcoinTestNet.Addr,
+		VtxoTapKey: pubKey,
+		Signer:     signerKey.PubKey(),
+	}
+	offchainAddr, err := arkAddr.EncodeV0()
+	require.NoError(t, err)
+
+	t.Run("valid onchain", func(t *testing.T) {
+		fixtures := []struct {
+			name    string
+			address string
+		}{
+			{"mainnet P2PKH", p2pkhMainnet.String()},
+			{"mainnet P2WPKH", p2wpkhMainnet.String()},
+			{"mainnet P2TR", p2trMainnet.String()},
+			{"testnet P2PKH", p2pkhTestnet.String()},
+			{"regtest P2TR", p2trRegtest.String()},
+		}
+		for _, f := range fixtures {
+			t.Run(f.name, func(t *testing.T) {
+				isOnchain, isOffchain, err := arksdk.ValidateAddress(f.address)
+				require.NoError(t, err)
+				require.True(t, isOnchain)
+				require.False(t, isOffchain)
+			})
+		}
+	})
+
+	t.Run("valid offchain", func(t *testing.T) {
+		isOnchain, isOffchain, err := arksdk.ValidateAddress(offchainAddr)
+		require.NoError(t, err)
+		require.False(t, isOnchain)
+		require.True(t, isOffchain)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		fixtures := []struct {
+			name    string
+			address string
+		}{
+			{"empty string", ""},
+			{"random garbage", "not-an-address"},
+			{"unknown bech32 prefix", "wrongprefix1qt9tfh7c09hlsstzq5y9tzuwyaesrwr8gpy8cn29cxv0flp64958s0n0yd0"},
+			{"truncated bech32", "bc1q"},
+			{"truncated ark address", offchainAddr[:len(offchainAddr)/2]},
+		}
+		for _, f := range fixtures {
+			t.Run(f.name, func(t *testing.T) {
+				isOnchain, isOffchain, err := arksdk.ValidateAddress(f.address)
+				require.Error(t, err)
+				require.False(t, isOnchain)
+				require.False(t, isOffchain)
+			})
+		}
+	})
 }


### PR DESCRIPTION
Adds an exported ValidateAddress(address string) function that infers
the network from the address prefix and returns whether it is a valid
Bitcoin onchain address or Ark offchain address, without requiring a
configured client.

https://claude.ai/code/session_0151wY6W7ib1h3HWof32Xz7q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added address validation supporting Bitcoin onchain formats and Ark offchain formats, improving input validation across the app.

* **Tests**
  * Added comprehensive tests covering valid onchain and offchain addresses and various invalid input cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->