### PR TITLE
fix: graceful shutdown of bg goroutines before DB close

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,6 +51,7 @@ type arkClient struct {
 	syncErr           error
 	syncListeners     *syncListeners
 	stopFn            context.CancelFunc
+	goroutineWg       sync.WaitGroup
 	stopOnce          sync.Once
 	refreshDbInterval time.Duration
 	dbMu              *sync.Mutex
@@ -267,6 +268,7 @@ func (a *arkClient) Reset(ctx context.Context) {
 
 	if a.stopFn != nil {
 		a.stopFn()
+		a.goroutineWg.Wait()
 	}
 	if a.syncListeners != nil {
 		a.syncListeners.broadcast(fmt.Errorf("wallet reset while restoring"))
@@ -290,6 +292,7 @@ func (a *arkClient) Stop() {
 
 		if a.stopFn != nil {
 			a.stopFn()
+			a.goroutineWg.Wait()
 		}
 		if a.syncListeners != nil {
 			a.syncListeners.broadcast(fmt.Errorf("service stopped while restoring"))
@@ -697,6 +700,7 @@ func groupSpentVtxosByTx(
 }
 
 func (a *arkClient) listenForArkTxs(ctx context.Context) {
+	defer a.goroutineWg.Done()
 	wallet := a.Wallet()
 	if wallet == nil {
 		// Should be unreachable
@@ -778,6 +782,7 @@ func (a *arkClient) listenForArkTxs(ctx context.Context) {
 }
 
 func (a *arkClient) listenForOnchainTxs(ctx context.Context) {
+	defer a.goroutineWg.Done()
 	wallet := a.Wallet()
 	if wallet == nil {
 		// Should be unreachable
@@ -1081,6 +1086,7 @@ func (a *arkClient) listenForOnchainTxs(ctx context.Context) {
 }
 
 func (a *arkClient) listenDbEvents(ctx context.Context) {
+	defer a.goroutineWg.Done()
 	for {
 		select {
 		case <-ctx.Done():
@@ -1139,6 +1145,7 @@ func (a *arkClient) listenDbEvents(ctx context.Context) {
 }
 
 func (a *arkClient) periodicRefreshDb(ctx context.Context) {
+	defer a.goroutineWg.Done()
 	if a.refreshDbInterval == 0 {
 		return
 	}

--- a/init.go
+++ b/init.go
@@ -101,6 +101,7 @@ func (a *arkClient) Unlock(ctx context.Context, password string) error {
 	bgCtx, cancel := context.WithCancel(context.Background())
 	a.stopFn = cancel
 
+	a.goroutineWg.Add(4)
 	go func() {
 		a.Explorer().Start()
 
@@ -136,6 +137,7 @@ func (a *arkClient) Lock(ctx context.Context) error {
 
 	if a.stopFn != nil {
 		a.stopFn()
+		a.goroutineWg.Wait()
 	}
 	if a.syncListeners != nil {
 		a.syncListeners.broadcast(fmt.Errorf("wallet locked while restoring"))

--- a/init.go
+++ b/init.go
@@ -99,10 +99,11 @@ func (a *arkClient) Unlock(ctx context.Context, password string) error {
 	}()
 
 	bgCtx, cancel := context.WithCancel(context.Background())
+	a.goroutineWg.Add(1)
 	a.stopFn = cancel
-
-	a.goroutineWg.Add(4)
 	go func() {
+		defer a.goroutineWg.Done()
+
 		a.Explorer().Start()
 
 		ctx := bgCtx
@@ -111,7 +112,12 @@ func (a *arkClient) Unlock(ctx context.Context, password string) error {
 		a.syncCh <- err
 		close(a.syncCh)
 
+		if err != nil {
+			return
+		}
+
 		// start listening to stream events
+		a.goroutineWg.Add(4)
 		go a.listenForArkTxs(ctx)
 		go a.listenForOnchainTxs(ctx)
 		go a.listenDbEvents(ctx)


### PR DESCRIPTION
fixes #154

Added a `goroutineWg sync.WaitGroup` to arkClient to track the 4 background goroutines `(listenForArkTxs, listenForOnchainTxs, listenDbEvents, periodicRefreshDb). Add(4)` is called before the outer goroutine in `Unlock()` so the counter is set before any shutdown can race it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown synchronization to ensure background processes properly terminate before lock/unlock transitions complete, enhancing reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->