### PR TITLE
test: failing tests + docs for review of #160

### DIFF
--- a/explorer/electrum/break_test.go
+++ b/explorer/electrum/break_test.go
@@ -1,0 +1,303 @@
+package electrum_explorer_test
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	electrum_explorer "github.com/arkade-os/go-sdk/explorer/electrum"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBreak_ConcurrentSubscribeSameAddress probes the TOCTOU window between
+// the RLock pre-check and the Lock confirm in SubscribeForAddresses. If
+// electrumClient.subscribe overwrites c.subs[sh] without dedup, the loser
+// orphans a notif channel and Stop() blocks on notifWg.Wait().
+func TestBreak_ConcurrentSubscribeSameAddress(t *testing.T) {
+	const addr = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+
+	serverURL := startMockServer(t, func(conn net.Conn, req map[string]json.RawMessage) {
+		switch reqMethod(req) {
+		case "server.version":
+			writeResponse(conn, reqID(req), []string{"mock", "1.4"})
+		case "blockchain.scripthash.listunspent":
+			time.Sleep(20 * time.Millisecond) // widen the TOCTOU window
+			writeResponse(conn, reqID(req), []any{})
+		case "blockchain.scripthash.subscribe":
+			writeResponse(conn, reqID(req), nil)
+		}
+	})
+
+	exp, err := electrum_explorer.NewExplorer(serverURL, arklib.Bitcoin,
+		electrum_explorer.WithTracker(true))
+	require.NoError(t, err)
+	exp.Start()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); _ = exp.SubscribeForAddresses([]string{addr}) }()
+	}
+	wg.Wait()
+
+	done := make(chan struct{})
+	go func() { exp.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Stop() hung — orphan notifCh from concurrent SubscribeForAddresses")
+	}
+}
+
+// TestBreak_GetAddressesEventsLeaksWhenTrackerOff documents that calling
+// GetAddressesEvents on a no-tracker explorer returns a never-closed channel.
+func TestBreak_GetAddressesEventsLeaksWhenTrackerOff(t *testing.T) {
+	exp, err := electrum_explorer.NewExplorer("tcp://127.0.0.1:1", arklib.Bitcoin,
+		electrum_explorer.WithTracker(false))
+	require.NoError(t, err)
+	ch := exp.GetAddressesEvents()
+	require.NotNil(t, ch)
+
+	exp.Stop()
+
+	select {
+	case _, ok := <-ch:
+		require.False(t, ok, "channel should be closed after Stop")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("GetAddressesEvents channel never closes — consumer goroutine leaks forever")
+	}
+}
+
+// TestBreak_GetTxOutspendsHidesRPCError verifies that an RPC error in the
+// per-output history scan is surfaced rather than being interpreted as
+// "output is unspent".
+func TestBreak_GetTxOutspendsHidesRPCError(t *testing.T) {
+	const txid = "tgt"
+	serverURL := startMockServer(t, func(conn net.Conn, req map[string]json.RawMessage) {
+		switch reqMethod(req) {
+		case "server.version":
+			writeResponse(conn, reqID(req), []string{"mock", "1.4"})
+		case "blockchain.transaction.get":
+			writeResponse(conn, reqID(req), map[string]any{
+				"txid": txid, "vin": []any{},
+				"vout": []any{
+					map[string]any{
+						"n":            0,
+						"scriptpubkey": map[string]any{"hex": "51"},
+						"value":        0.001,
+					},
+				},
+				"blockheight": 100, "confirmations": 1, "blocktime": 0,
+			})
+		case "blockchain.scripthash.get_history":
+			resp := fmt.Sprintf(
+				`{"id":%d,"error":{"code":-32603,"message":"internal error"}}`+"\n",
+				reqID(req))
+			_, _ = conn.Write([]byte(resp))
+		}
+	})
+
+	exp, err := electrum_explorer.NewExplorer(serverURL, arklib.Bitcoin,
+		electrum_explorer.WithTracker(false))
+	require.NoError(t, err)
+	exp.Start()
+	defer exp.Stop()
+
+	outspends, err := exp.GetTxOutspends(txid)
+	if err == nil {
+		require.NotEqual(t, false, outspends[0].Spent,
+			"RPC error reported as Spent=false — caller cannot distinguish error from unspent")
+	}
+}
+
+// TestBreak_StartIsIdempotent stresses concurrent Start() calls and asserts
+// only one TCP connection is established. A second connection means the
+// first one was leaked.
+func TestBreak_StartIsIdempotent(t *testing.T) {
+	var conns atomic.Int32
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() }) // nolint
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conns.Add(1)
+			go serveConn(c, func(conn net.Conn, req map[string]json.RawMessage) {
+				if reqMethod(req) == "server.version" {
+					writeResponse(conn, reqID(req), []string{"mock", "1.4"})
+				}
+			})
+		}
+	}()
+
+	exp, err := electrum_explorer.NewExplorer("tcp://"+ln.Addr().String(), arklib.Bitcoin,
+		electrum_explorer.WithTracker(false))
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); exp.Start() }()
+	}
+	wg.Wait()
+	defer exp.Stop()
+	time.Sleep(300 * time.Millisecond)
+
+	require.LessOrEqualf(t, conns.Load(), int32(1),
+		"Start() spawned %d TCP connections; second connection leaked", conns.Load())
+}
+
+// TestBreak_GetTxBlockTimeUnconfirmedSentinelMismatch documents that the
+// unconfirmed sentinel disagrees across explorer methods (-1 here, 0 elsewhere).
+func TestBreak_GetTxBlockTimeUnconfirmedSentinelMismatch(t *testing.T) {
+	const txid = "u"
+
+	serverURL := startMockServer(t, func(conn net.Conn, req map[string]json.RawMessage) {
+		switch reqMethod(req) {
+		case "server.version":
+			writeResponse(conn, reqID(req), []string{"mock", "1.4"})
+		case "blockchain.transaction.get":
+			writeResponse(conn, reqID(req), map[string]any{
+				"txid": txid, "vin": []any{}, "vout": []any{},
+				"blockheight": -1, "confirmations": 0, "blocktime": 0,
+			})
+		}
+	})
+
+	exp, err := electrum_explorer.NewExplorer(serverURL, arklib.Bitcoin,
+		electrum_explorer.WithTracker(false))
+	require.NoError(t, err)
+	exp.Start()
+	defer exp.Stop()
+
+	_, bt, err := exp.GetTxBlockTime(txid)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), bt,
+		"GetUtxos/GetTxs report BlockTime=0 for unconfirmed; GetTxBlockTime must match (returns -1)")
+}
+
+// TestBreak_PendingRequestHangsOnDisconnect verifies that an in-flight request
+// fails fast when the connection drops, instead of waiting the full 15 s
+// requestTimeout. listen()'s reconnect path currently does NOT flush c.pending,
+// so callers wait for their individual timeouts before learning the conn died.
+//
+// Real-world impact: during wallet restore (discoverHDWalletKeys fires hundreds
+// of GetTxs in succession), if the server restarts mid-restore, every in-flight
+// request blocks the restore for 15 s × in-flight count.
+func TestBreak_PendingRequestHangsOnDisconnect(t *testing.T) {
+	const dropDelay = 50 * time.Millisecond
+
+	serverURL := startMockServer(t, func(conn net.Conn, req map[string]json.RawMessage) {
+		switch reqMethod(req) {
+		case "server.version":
+			writeResponse(conn, reqID(req), []string{"mock", "1.4"})
+		case "blockchain.transaction.get":
+			// Simulate a server crash mid-request: never respond, just close.
+			go func() {
+				time.Sleep(dropDelay)
+				_ = conn.Close()
+			}()
+		}
+	})
+
+	exp, err := electrum_explorer.NewExplorer(serverURL, arklib.Bitcoin,
+		electrum_explorer.WithTracker(false))
+	require.NoError(t, err)
+	exp.Start()
+	defer exp.Stop()
+
+	start := time.Now()
+	_, err = exp.GetTxHex("any-txid-the-server-wont-answer")
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "request should fail after disconnect")
+
+	// With listen() flushing pending on disconnect → ~50 ms (dropDelay).
+	// Without the flush → 15 s (requestTimeout).
+	require.Lessf(t, elapsed, 2*time.Second,
+		"GetTxHex took %v after server disconnect; in-flight requests should fail "+
+			"fast when the connection dies, not wait the 15 s requestTimeout", elapsed)
+}
+
+// TestBreak_ResubscribeIsSerial verifies that scripthash resubscription after
+// a reconnect runs in parallel rather than one-RPC-at-a-time. With a wallet
+// that has many subscribed addresses (boarding + unrolled VTXOs + delegate
+// addresses), a serial resubscribe makes recovery time scale linearly with
+// the number of subscriptions.
+//
+// Strategy: subscribe to N addresses, force a reconnect by closing the first
+// connection, then time how long the resubscribe phase takes. With a 40 ms
+// per-subscribe simulated server delay, a serial implementation needs
+// N×40 ms; bounded parallelism (e.g. 8 workers) takes ≈80 ms regardless of N.
+func TestBreak_ResubscribeIsSerial(t *testing.T) {
+	const N = 12
+	const subscribeDelay = 40 * time.Millisecond
+
+	addrs := make([]string, 0, N)
+	for i := 1; i <= N; i++ {
+		prog := make([]byte, 20)
+		binary.BigEndian.PutUint64(prog[12:], uint64(i))
+		addr, err := btcutil.NewAddressWitnessPubKeyHash(prog, &chaincfg.MainNetParams)
+		require.NoError(t, err)
+		addrs = append(addrs, addr.EncodeAddress())
+	}
+
+	var subscribeCount atomic.Int32
+	firstConnCh := make(chan net.Conn, 1)
+	serverURL := startMockServer(t, func(conn net.Conn, req map[string]json.RawMessage) {
+		select {
+		case firstConnCh <- conn:
+		default:
+		}
+		switch reqMethod(req) {
+		case "server.version":
+			writeResponse(conn, reqID(req), []string{"mock", "1.4"})
+		case "blockchain.scripthash.listunspent":
+			writeResponse(conn, reqID(req), []any{})
+		case "blockchain.scripthash.subscribe":
+			subscribeCount.Add(1)
+			time.Sleep(subscribeDelay)
+			writeResponse(conn, reqID(req), nil)
+		}
+	})
+
+	exp, err := electrum_explorer.NewExplorer(serverURL, arklib.Bitcoin,
+		electrum_explorer.WithTracker(true))
+	require.NoError(t, err)
+	exp.Start()
+	defer exp.Stop()
+
+	require.NoError(t, exp.SubscribeForAddresses(addrs))
+	require.Eventually(t, func() bool { return subscribeCount.Load() >= int32(N) },
+		15*time.Second, 50*time.Millisecond, "initial subscribes never completed")
+
+	// Reset for the resubscribe phase, then drop the first connection.
+	subscribeCount.Store(0)
+	initial := <-firstConnCh
+	_ = initial.Close()
+
+	start := time.Now()
+	require.Eventually(t, func() bool { return subscribeCount.Load() >= int32(N) },
+		20*time.Second, 50*time.Millisecond, "resubscribe never completed")
+	elapsed := time.Since(start)
+
+	serialBaseline := time.Duration(N) * subscribeDelay // 12 × 40 ms = 480 ms
+	parallelThreshold := serialBaseline / 3             // ≈ 160 ms (allows for partial overlap)
+
+	require.Lessf(t, elapsed, parallelThreshold,
+		"resubscribe of %d addresses took %v; serial baseline = %v; "+
+			"reconnect should parallelise resubscribes (target < %v)",
+		N, elapsed, serialBaseline, parallelThreshold)
+}

--- a/explorer/electrum/client.go
+++ b/explorer/electrum/client.go
@@ -24,39 +24,79 @@ const (
 	maxScannerBytes    = 1 << 20 // 1 MB — large enough for verbose txs
 )
 
+// electrumClient owns the JSON-RPC transport: a single multiplexed TCP/SSL
+// connection, a pending-request map keyed by atomic request IDs, and the
+// listen + keepAlive goroutine pair that drives the connection.
+//
+// See doc.go for the package-level reconnection model. The dual-context
+// pattern (root c.ctx vs per-cycle cycleCtx) is what bounds goroutine
+// lifetimes across reconnects — see the cycleMu/cycleCancel field comment.
 type electrumClient struct {
 	serverURL string
 	tlsConfig *tls.Config // nil = default TLS config (system roots, TLS 1.2+)
 
+	// conn is the live TCP/SSL connection. Replaced (without nil-ing the old
+	// pointer) by reconnect() on every successful redial. Reads must go
+	// through getConn() under connMu's RLock; writes go through setConn().
 	conn   net.Conn
 	connMu sync.RWMutex // protects c.conn pointer only
 
-	writeMu sync.Mutex // serializes all conn.Write calls so frames don't interleave
+	// writeMu serialises all conn.Write calls so JSON-RPC frames are never
+	// interleaved on the wire. Held only across the single Write — no slow
+	// work happens inside its critical section.
+	writeMu sync.Mutex
 
+	// reqID feeds atomic, monotonically-increasing JSON-RPC request IDs.
+	// pending maps id → response channel; the listen() goroutine fulfils
+	// each request by looking up the id and sending on its channel.
 	reqID   atomic.Uint64
 	pending map[uint64]chan *jsonRPCResponse
 	pendMu  sync.Mutex
 
 	// subs maps scripthash → channel that receives new status hash strings
-	// whenever ElectrumX pushes a blockchain.scripthash.subscribe notification.
+	// whenever ElectrumX pushes a blockchain.scripthash.subscribe
+	// notification. Read by listen() under RLock; written by subscribe() and
+	// unsubscribeLocal() under Lock. Channels are buffered (8) so that a
+	// momentarily-slow consumer does not block the listen() goroutine.
 	subs   map[string]chan string
 	subsMu sync.RWMutex
 
-	// storedSubs is replayed in full on every reconnect.
-	// storedSubsMu is kept separate from subsMu because subscribe() must not
-	// hold either lock while doing the blocking RPC call, so the two maps are
-	// updated independently under their own locks.
+	// storedSubs is the durable list of scripthashes to resubscribe after a
+	// reconnect. Maintained alongside subs by subscribe()/unsubscribeLocal().
+	//
+	// storedSubsMu is kept separate from subsMu so that subscribe() can drop
+	// one lock before taking the other (enforcing lock ordering) and so that
+	// neither lock is held while issuing the blocking
+	// blockchain.scripthash.subscribe RPC.
 	storedSubs   []string
 	storedSubsMu sync.Mutex
 
+	// reconnectMu serialises reconnect attempts so only one goroutine ever
+	// runs the redial loop at a time. Required because both the natural
+	// disconnect path (listen() exit) and the failed-initial-connect path
+	// (Start()) can call reconnect concurrently.
 	reconnectMu sync.Mutex
 
+	// ctx / cancel — the ROOT context. Cancelled only by shutdown() which is
+	// reached via explorerSvc.Stop(). Used to:
+	//   - parent every per-cycle context so they all die at shutdown,
+	//   - unblock the reconnect loop's time.After backoff,
+	//   - bound the requestTimeout context so in-flight requests fail at
+	//     shutdown rather than waiting their full 15 s timeout.
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	// cycleMu/cycleCancel track the current listen+keepAlive goroutine pair.
-	// Cancelling the cycle context signals both goroutines to stop before a new
-	// pair is started, preventing accumulation across reconnects.
+	// cycleMu / cycleCancel — the PER-CONNECTION-CYCLE context handle.
+	//
+	// Each successful connect spawns a fresh listen + keepAlive goroutine
+	// pair under a new context derived from c.ctx. cycleCancel is the cancel
+	// fn for that derived context. On the next reconnect, newCycleCtx()
+	// cancels the previous cycleCtx (terminating the old listen + keepAlive
+	// goroutines) BEFORE spawning the new pair.
+	//
+	// Without this, every reconnect would leak two goroutines: the old
+	// listen() (still trying to read the closed conn) and the old
+	// keepAlive() (still pinging via c.request).
 	cycleMu     sync.Mutex
 	cycleCancel context.CancelFunc
 }

--- a/explorer/electrum/doc.go
+++ b/explorer/electrum/doc.go
@@ -1,0 +1,123 @@
+// Package electrum_explorer provides an Explorer implementation backed by an
+// ElectrumX server over TCP or SSL. It is modeled on the ocean project's
+// electrum blockchain scanner and requires no third-party ElectrumX library.
+//
+// # Overview
+//
+// The package has two layers:
+//
+//   - electrumClient (transport, client.go) — owns a single multiplexed
+//     TCP/SSL connection. Multiplexes JSON-RPC requests via atomic request
+//     IDs over one socket, runs a listen + keepAlive goroutine pair per
+//     connection cycle, and reconnects with exponential backoff on any
+//     disconnect.
+//
+//   - explorerSvc (protocol, explorer.go) — implements the
+//     explorer.Explorer interface. Does Bitcoin-aware encoding/decoding,
+//     address tracking with a poll loop, and event broadcasting through a
+//     non-blocking listeners hub.
+//
+// Both layers are safe to call from any goroutine; internal locks serialise
+// concurrent access. Callers do not need to provide their own synchronisation.
+//
+// # Lifecycle
+//
+// The Explorer transitions through these states:
+//
+//	created  ─Start()─►  connecting  ─handshake OK─►  ready  ─Stop()─►  stopped
+//	                          │
+//	                          └─dial fail─► (background reconnect goroutine)
+//
+//	ready  ─clean EOF / I/O err─►  reconnecting  ─dial OK + handshake─►  ready
+//	                                     │
+//	                                     └─dial fail─► (exp. backoff 5 s → 60 s)
+//
+// Start dials, completes the server.version handshake, and (if tracking is
+// enabled) launches the polling loop. Stop cancels the root context, drains
+// per-address notification consumers, closes listener channels, and resets
+// the subscription map.
+//
+// # Reconnection model
+//
+// The connection is owned by electrumClient. On any disconnect — including a
+// clean EOF from a server restart — listen() exits and falls through to
+// reconnect(). reconnect dials with exponential backoff and, on success,
+// replays every scripthash recorded in storedSubs by issuing a fresh
+// blockchain.scripthash.subscribe RPC per address.
+//
+// Two contexts cooperate to bound goroutine lifetimes:
+//
+//   - c.ctx / c.cancel — the root context. Cancelled only by shutdown(),
+//     which is reached via explorerSvc.Stop(). Unblocks the reconnect loop's
+//     time.After backoff and prevents zombie reconnect goroutines from
+//     outliving the explorer.
+//
+//   - cycleCtx / cycleCancel — a per-connection-cycle context. Cancelled at
+//     every reconnect to terminate the listen + keepAlive goroutine pair of
+//     the previous cycle. The new cycle starts a fresh pair under a fresh
+//     context. This is what prevents goroutine accumulation across multiple
+//     reconnects in one process lifetime — without it every reconnect would
+//     leak two goroutines.
+//
+// Pending requests in c.pending are drained when close() is called (either
+// from a failed connect or from shutdown). On a natural disconnect-then-
+// reconnect path the pending map is left intact across the gap; in-flight
+// requests time out individually after requestTimeout (default 15 s).
+//
+// # Restart and restore semantics
+//
+// The explorer is stateless across process boundaries by design. The only
+// piece of explorer-related state persisted by the surrounding SDK is the
+// server URL (recorded in arkClient's ConfigStore via Init). On a fresh
+// process start, the path is:
+//
+//  1. LoadArkClient reads the persisted URL from ConfigStore.
+//  2. newExplorer (init.go) dispatches on URL scheme:
+//     "tcp://" or "ssl://" → this package; anything else → mempool.space.
+//  3. NewExplorer constructs a fresh electrumClient with empty subscription
+//     and cache state.
+//  4. Unlock() calls Explorer().Start(), which dials, runs
+//     discoverHDWalletKeys + refreshDb to rebuild wallet state from the
+//     persistent store + chain, then hands off to the polling loop.
+//
+// During restore the SDK fires bursts of GetTxs / GetUtxos calls. The
+// transport multiplexes them on the single TCP connection via atomic request
+// IDs — but they all share one 15 s requestTimeout per call, so a slow
+// server stalls the burst rather than parallelising it.
+//
+// Anyone refactoring this package should NOT introduce on-disk explorer
+// state without also adding a corresponding crash-recovery path. The current
+// design is deliberate: the persistent state-of-record lives in arkd and the
+// SDK's app-data store; the explorer is a fresh, transient view of it.
+//
+// # Concurrency contract
+//
+// All exported methods on the Explorer interface are safe to call from any
+// goroutine. Implementation notes:
+//
+//   - Address subscriptions are protected by subscribedMu (RWMutex on the
+//     map) plus a per-address state.mu that serialises concurrent
+//     pollAddress calls for the same address.
+//   - The listeners hub uses an RWMutex around the listener-channel map;
+//     broadcasts non-blockingly fan out to every consumer and auto-evict
+//     consumers that fall behind.
+//   - The transport-level c.subs map (scripthash → notif channel) is
+//     protected by subsMu and is read/written by listen() under RLock and
+//     by subscribe/unsubscribeLocal under Lock.
+//   - storedSubs is replayed on every reconnect; it is protected by its own
+//     mutex separate from subsMu so that subscribe() can drop one lock
+//     before acquiring the other (enforces lock ordering and avoids holding
+//     either lock across a blocking RPC).
+//
+// # Known limitations vs the mempool.space explorer
+//
+//   - Broadcast of multiple txs is sequential, not atomic.
+//   - UnsubscribeForAddresses removes the address locally only; ElectrumX
+//     has no unsubscribe wire message.
+//   - OnchainAddressEvent.Replacements is always empty (ElectrumX has no
+//     RBF notification).
+//   - GetConnectionCount always returns 1 (single multiplexed TCP
+//     connection).
+//   - GetTxOutspends is O(outputs × history length) rather than a dedicated
+//     endpoint.
+package electrum_explorer

--- a/explorer/electrum/explorer.go
+++ b/explorer/electrum/explorer.go
@@ -1,13 +1,5 @@
-// Package electrum_explorer provides an Explorer implementation backed by an
-// ElectrumX server over TCP or SSL. It is modeled on the ocean project's
-// electrum blockchain scanner and requires no third-party ElectrumX library.
-//
-// Known limitations vs the mempool.space explorer:
-//   - Broadcast of multiple txs is sequential, not atomic.
-//   - UnsubscribeForAddresses removes the address locally only; ElectrumX has no unsubscribe wire message.
-//   - OnchainAddressEvent.Replacements is always empty (ElectrumX has no RBF notification).
-//   - GetConnectionCount always returns 1 (single multiplexed TCP connection).
-//   - GetTxOutspends is O(outputs × history length) rather than a dedicated endpoint.
+// See doc.go for the package-level overview, lifecycle, reconnection model,
+// and restart/restore semantics.
 package electrum_explorer
 
 import (
@@ -112,6 +104,25 @@ func networkToChainParams(net arklib.Network) *chaincfg.Params {
 	}
 }
 
+// Start dials the ElectrumX server, performs the server.version handshake,
+// and (if tracking is enabled via WithTracker(true)) launches the poll loop
+// over subscribed addresses.
+//
+// If the initial connect fails Start does NOT return an error — it logs a
+// warning and spawns a background goroutine that retries via the same
+// exponential-backoff reconnect path used after a mid-life disconnect.
+// Callers can observe connection state via GetConnectionCount() if they need
+// to gate logic on "is the explorer ready?".
+//
+// Start is invoked by arkClient.Unlock(). On a fresh process start the path
+// is: LoadArkClient (reads URL from ConfigStore) → newExplorer (constructs
+// a fresh transport with empty subscription/cache state) → Unlock →
+// Explorer().Start(). See doc.go § "Restart and restore semantics".
+//
+// Concurrency: NOT idempotent in the current implementation. Concurrent
+// Start() calls dial multiple connections; only the most-recently-dialed
+// conn is reachable via c.conn, the rest leak. Callers should ensure Start
+// is called exactly once between matching Stop() calls.
 func (e *explorerSvc) Start() {
 	if err := e.client.connect(); err != nil {
 		log.WithError(err).Warn("electrum explorer: initial connect failed, retrying in background")
@@ -132,6 +143,26 @@ func (e *explorerSvc) Start() {
 	log.Debug("electrum explorer: started")
 }
 
+// Stop terminates the explorer in this order:
+//
+//  1. Closes the poll-loop stop channel — pollLoop returns on its next tick.
+//  2. Calls client.shutdown() — cancels the root context, closes the live
+//     conn, and drains in-flight pending requests so callers fail fast with
+//     "connection closed waiting for X" instead of waiting requestTimeout.
+//  3. Calls unsubscribeLocal for every subscribed address — closes each
+//     per-address notif channel, which causes the per-address consumer
+//     goroutine spawned in SubscribeForAddresses to exit.
+//  4. Waits on notifWg until every per-address consumer has exited.
+//  5. Clears the listeners hub — closes every consumer event channel.
+//
+// Stop is invoked by arkClient.Lock(). After Stop returns, the explorer
+// should not be reused: the root context is permanently cancelled and the
+// transport is unrecoverable. To resume operation, construct a fresh
+// Explorer via newExplorer.
+//
+// Concurrency: not safe to call concurrently with itself. Safe to call
+// concurrently with one-shot RPC methods (GetTxHex, etc.) — those will see
+// "connection closed" errors as part of step 2.
 func (e *explorerSvc) Stop() {
 	if e.stopTracking != nil {
 		e.stopTracking()


### PR DESCRIPTION
This is a **review companion** for #160 — not a merge candidate.

While reviewing I added 7 failing tests that each reproduce a bug
deterministically, plus a docs-only commit covering lifecycle,
reconnection model, and restart/restore semantics.

## Failing tests

| # | Test | Bug | Severity |
|---|------|-----|----------|
| 1 | `TestBreak_ConcurrentSubscribeSameAddress` | TOCTOU race in `SubscribeForAddresses` orphans `notifCh` → `Stop()` deadlocks | 🔴 |
| 2 | `TestBreak_GetAddressesEventsLeaksWhenTrackerOff` | Returns a never-closed channel when tracker disabled → consumer goroutine leaks | 🔴 |
| 3 | `TestBreak_StartIsIdempotent` | N concurrent `Start()` calls dial N TCP sockets; N-1 leaked | 🔴 |
| 4 | `TestBreak_PendingRequestHangsOnDisconnect` | In-flight requests block 15 s on `requestTimeout` instead of failing fast on disconnect | 🔴 |
| 5 | `TestBreak_ResubscribeIsSerial` | Reconnect resubscribes scripthashes serially → recovery time scales linearly with subscription count | 🟠 |
| 6 | `TestBreak_GetTxOutspendsHidesRPCError` | RPC errors silently surface as `Spent=false`; caller can't distinguish error from "unspent" | 🟡 |
| 7 | `TestBreak_GetTxBlockTimeUnconfirmedSentinelMismatch` | Returns `-1` for unconfirmed; `GetUtxos`/`GetTxs` use `0` everywhere else | ⚪ |

I also reproduced #1 as a hard process panic (`send on closed channel`
at `client.go:433`) against a live electrs server in regtest — happy
to share the integration test if useful.

## Docs commit

Adds `explorer/electrum/doc.go` with a package overview, lifecycle
state diagram, reconnection model, and restart/restore semantics.
Also adds field-level comments on `electrumClient` (the dual-context
pattern) and contracts on `Start()` / `Stop()`. No behaviour changes.

## How to use this PR

@bobsmith feel free to:
- Absorb tests and docs verbatim → fix the bugs in your branch.
- Cherry-pick selectively.
- Dismiss any test you disagree with (mark wontfix in the thread).

I'll re-review your fixes once you're ready. Happy to pair on any of
the bugs if it'd help.