### PR TITLE
Fix uint64 underflow in sent amount calculation for commitment txs

### DIFF
--- a/client.go
+++ b/client.go
@@ -1398,7 +1398,7 @@ func (a *arkClient) handleCommitmentTx(
 			}
 		}
 	} else {
-		if amount, txType, ok := committedNetAmount(myVtxos, pendingBoardingTxs, vtxosToAdd); ok {
+		if amount, txType, ok := commitmentTxNetAmount(myVtxos, pendingBoardingTxs, vtxosToAdd); ok {
 			txsToAdd = append(txsToAdd, clientTypes.Transaction{
 				TransactionKey: clientTypes.TransactionKey{
 					CommitmentTxid: commitmentTx.Txid,
@@ -1520,7 +1520,7 @@ func (a *arkClient) handleArkTx(
 			})
 		}
 	} else {
-		if amount, txType, ok := arkNetAmount(myVtxos, vtxosToAdd); ok {
+		if amount, txType, ok := arkTxNetAmount(myVtxos, vtxosToAdd); ok {
 			txsToAdd = append(txsToAdd, clientTypes.Transaction{
 				TransactionKey: clientTypes.TransactionKey{
 					ArkTxid: arkTx.Txid,
@@ -2095,10 +2095,10 @@ func (a *arkClient) saveBatchTransaction(
 	return nil
 }
 
-// committedNetAmount returns the net amount a commitment tx moves for us and
+// commitmentTxNetAmount returns the net amount a commitment tx moves for us and
 // its direction. ok is false when our inputs equal our outputs (nothing to
-// record). Boarding utxos count as inputs since they are funds we contributed.
-func committedNetAmount(
+// record).
+func commitmentTxNetAmount(
 	myVtxos []clientTypes.Vtxo,
 	boardingTxs []clientTypes.Transaction,
 	vtxosToAdd []clientTypes.Vtxo,
@@ -2117,9 +2117,9 @@ func committedNetAmount(
 	return netAmount(totalIn, totalOut)
 }
 
-// arkNetAmount returns the net amount an ark tx moves for us and its direction.
+// arkTxNetAmount returns the net amount an ark tx moves for us and its direction.
 // ok is false when our inputs equal our outputs (nothing to record).
-func arkNetAmount(myVtxos, vtxosToAdd []clientTypes.Vtxo) (amount uint64, txType clientTypes.TxType, ok bool) {
+func arkTxNetAmount(myVtxos, vtxosToAdd []clientTypes.Vtxo) (amount uint64, txType clientTypes.TxType, ok bool) {
 	totalIn := uint64(0)
 	for _, v := range myVtxos {
 		totalIn += v.Amount

--- a/client.go
+++ b/client.go
@@ -1398,13 +1398,13 @@ func (a *arkClient) handleCommitmentTx(
 			}
 		}
 	} else {
-		if sent, ok := committedSentAmount(myVtxos, pendingBoardingTxs, vtxosToAdd); ok {
+		if amount, txType, ok := committedNetAmount(myVtxos, pendingBoardingTxs, vtxosToAdd); ok {
 			txsToAdd = append(txsToAdd, clientTypes.Transaction{
 				TransactionKey: clientTypes.TransactionKey{
 					CommitmentTxid: commitmentTx.Txid,
 				},
-				Amount:    sent,
-				Type:      clientTypes.TxSent,
+				Amount:    amount,
+				Type:      txType,
 				CreatedAt: time.Now(),
 				Hex:       commitmentTx.Tx,
 			})
@@ -1520,14 +1520,13 @@ func (a *arkClient) handleArkTx(
 			})
 		}
 	} else {
-		// Otherwise, add a new spent tx to the history.
-		if sent, ok := arkSentAmount(myVtxos, vtxosToAdd); ok {
+		if amount, txType, ok := arkNetAmount(myVtxos, vtxosToAdd); ok {
 			txsToAdd = append(txsToAdd, clientTypes.Transaction{
 				TransactionKey: clientTypes.TransactionKey{
 					ArkTxid: arkTx.Txid,
 				},
-				Amount:      sent,
-				Type:        clientTypes.TxSent,
+				Amount:      amount,
+				Type:        txType,
 				CreatedAt:   time.Now(),
 				AssetPacket: assetPacket,
 				Hex:         arkTx.Tx,
@@ -2096,11 +2095,14 @@ func (a *arkClient) saveBatchTransaction(
 	return nil
 }
 
-func committedSentAmount(
+// committedNetAmount returns the net amount a commitment tx moves for us and
+// its direction. ok is false when our inputs equal our outputs (nothing to
+// record). Boarding utxos count as inputs since they are funds we contributed.
+func committedNetAmount(
 	myVtxos []clientTypes.Vtxo,
 	boardingTxs []clientTypes.Transaction,
 	vtxosToAdd []clientTypes.Vtxo,
-) (uint64, bool) {
+) (amount uint64, txType clientTypes.TxType, ok bool) {
 	totalIn := uint64(0)
 	for _, v := range myVtxos {
 		totalIn += v.Amount
@@ -2112,23 +2114,30 @@ func committedSentAmount(
 	for _, v := range vtxosToAdd {
 		totalOut += v.Amount
 	}
-	if totalIn > totalOut {
-		return totalIn - totalOut, true
-	}
-	return 0, false
+	return netAmount(totalIn, totalOut)
 }
 
-func arkSentAmount(myVtxos, vtxosToAdd []clientTypes.Vtxo) (uint64, bool) {
-	inAmount := uint64(0)
+// arkNetAmount returns the net amount an ark tx moves for us and its direction.
+// ok is false when our inputs equal our outputs (nothing to record).
+func arkNetAmount(myVtxos, vtxosToAdd []clientTypes.Vtxo) (amount uint64, txType clientTypes.TxType, ok bool) {
+	totalIn := uint64(0)
 	for _, v := range myVtxos {
-		inAmount += v.Amount
+		totalIn += v.Amount
 	}
-	outAmount := uint64(0)
+	totalOut := uint64(0)
 	for _, v := range vtxosToAdd {
-		outAmount += v.Amount
+		totalOut += v.Amount
 	}
-	if inAmount > outAmount {
-		return inAmount - outAmount, true
+	return netAmount(totalIn, totalOut)
+}
+
+func netAmount(totalIn, totalOut uint64) (uint64, clientTypes.TxType, bool) {
+	switch {
+	case totalIn > totalOut:
+		return totalIn - totalOut, clientTypes.TxSent, true
+	case totalOut > totalIn:
+		return totalOut - totalIn, clientTypes.TxReceived, true
+	default:
+		return 0, "", false
 	}
-	return 0, false
 }

--- a/client.go
+++ b/client.go
@@ -1398,7 +1398,8 @@ func (a *arkClient) handleCommitmentTx(
 			}
 		}
 	} else {
-		if amount, txType, ok := commitmentTxNetAmount(myVtxos, pendingBoardingTxs, vtxosToAdd); ok {
+		amount, txType, ok := commitmentTxNetAmount(myVtxos, pendingBoardingTxs, vtxosToAdd)
+		if ok {
 			txsToAdd = append(txsToAdd, clientTypes.Transaction{
 				TransactionKey: clientTypes.TransactionKey{
 					CommitmentTxid: commitmentTx.Txid,
@@ -2119,7 +2120,9 @@ func commitmentTxNetAmount(
 
 // arkTxNetAmount returns the net amount an ark tx moves for us and its direction.
 // ok is false when our inputs equal our outputs (nothing to record).
-func arkTxNetAmount(myVtxos, vtxosToAdd []clientTypes.Vtxo) (amount uint64, txType clientTypes.TxType, ok bool) {
+func arkTxNetAmount(
+	myVtxos, vtxosToAdd []clientTypes.Vtxo,
+) (amount uint64, txType clientTypes.TxType, ok bool) {
 	totalIn := uint64(0)
 	for _, v := range myVtxos {
 		totalIn += v.Amount

--- a/client.go
+++ b/client.go
@@ -1398,24 +1398,12 @@ func (a *arkClient) handleCommitmentTx(
 			}
 		}
 	} else {
-		totalIn := uint64(0)
-		for _, v := range myVtxos {
-			totalIn += v.Amount
-		}
-		for _, tx := range pendingBoardingTxs {
-			totalIn += tx.Amount
-		}
-		totalOut := uint64(0)
-		for _, v := range vtxosToAdd {
-			totalOut += v.Amount
-		}
-
-		if totalIn > totalOut {
+		if sent, ok := committedSentAmount(myVtxos, pendingBoardingTxs, vtxosToAdd); ok {
 			txsToAdd = append(txsToAdd, clientTypes.Transaction{
 				TransactionKey: clientTypes.TransactionKey{
 					CommitmentTxid: commitmentTx.Txid,
 				},
-				Amount:    totalIn - totalOut,
+				Amount:    sent,
 				Type:      clientTypes.TxSent,
 				CreatedAt: time.Now(),
 				Hex:       commitmentTx.Tx,
@@ -1533,24 +1521,18 @@ func (a *arkClient) handleArkTx(
 		}
 	} else {
 		// Otherwise, add a new spent tx to the history.
-		inAmount := uint64(0)
-		for _, vtxo := range myVtxos {
-			inAmount += vtxo.Amount
+		if sent, ok := arkSentAmount(myVtxos, vtxosToAdd); ok {
+			txsToAdd = append(txsToAdd, clientTypes.Transaction{
+				TransactionKey: clientTypes.TransactionKey{
+					ArkTxid: arkTx.Txid,
+				},
+				Amount:      sent,
+				Type:        clientTypes.TxSent,
+				CreatedAt:   time.Now(),
+				AssetPacket: assetPacket,
+				Hex:         arkTx.Tx,
+			})
 		}
-		outAmount := uint64(0)
-		for _, vtxo := range vtxosToAdd {
-			outAmount += vtxo.Amount
-		}
-		txsToAdd = append(txsToAdd, clientTypes.Transaction{
-			TransactionKey: clientTypes.TransactionKey{
-				ArkTxid: arkTx.Txid,
-			},
-			Amount:      inAmount - outAmount,
-			Type:        clientTypes.TxSent,
-			CreatedAt:   time.Now(),
-			AssetPacket: assetPacket,
-			Hex:         arkTx.Tx,
-		})
 	}
 
 	if len(txsToAdd) > 0 {
@@ -2112,4 +2094,41 @@ func (a *arkClient) saveBatchTransaction(
 	}
 
 	return nil
+}
+
+func committedSentAmount(
+	myVtxos []clientTypes.Vtxo,
+	boardingTxs []clientTypes.Transaction,
+	vtxosToAdd []clientTypes.Vtxo,
+) (uint64, bool) {
+	totalIn := uint64(0)
+	for _, v := range myVtxos {
+		totalIn += v.Amount
+	}
+	for _, tx := range boardingTxs {
+		totalIn += tx.Amount
+	}
+	totalOut := uint64(0)
+	for _, v := range vtxosToAdd {
+		totalOut += v.Amount
+	}
+	if totalIn > totalOut {
+		return totalIn - totalOut, true
+	}
+	return 0, false
+}
+
+func arkSentAmount(myVtxos, vtxosToAdd []clientTypes.Vtxo) (uint64, bool) {
+	inAmount := uint64(0)
+	for _, v := range myVtxos {
+		inAmount += v.Amount
+	}
+	outAmount := uint64(0)
+	for _, v := range vtxosToAdd {
+		outAmount += v.Amount
+	}
+	if inAmount > outAmount {
+		return inAmount - outAmount, true
+	}
+	return 0, false
 }

--- a/client.go
+++ b/client.go
@@ -1398,20 +1398,24 @@ func (a *arkClient) handleCommitmentTx(
 			}
 		}
 	} else {
-		amount := uint64(0)
+		totalIn := uint64(0)
 		for _, v := range myVtxos {
-			amount += v.Amount
+			totalIn += v.Amount
 		}
+		for _, tx := range pendingBoardingTxs {
+			totalIn += tx.Amount
+		}
+		totalOut := uint64(0)
 		for _, v := range vtxosToAdd {
-			amount -= v.Amount
+			totalOut += v.Amount
 		}
 
-		if amount > 0 {
+		if totalIn > totalOut {
 			txsToAdd = append(txsToAdd, clientTypes.Transaction{
 				TransactionKey: clientTypes.TransactionKey{
 					CommitmentTxid: commitmentTx.Txid,
 				},
-				Amount:    amount,
+				Amount:    totalIn - totalOut,
 				Type:      clientTypes.TxSent,
 				CreatedAt: time.Now(),
 				Hex:       commitmentTx.Tx,

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCommittedSentAmount(t *testing.T) {
+func TestCommittedNetAmount(t *testing.T) {
 	t.Parallel()
 
 	vtxo := func(amount uint64) clientTypes.Vtxo { return clientTypes.Vtxo{Amount: amount} }
@@ -19,50 +19,55 @@ func TestCommittedSentAmount(t *testing.T) {
 		boardingTxs []clientTypes.Transaction
 		vtxosToAdd  []clientTypes.Vtxo
 		wantAmount  uint64
-		wantSent    bool
+		wantType    clientTypes.TxType
+		wantOk      bool
 	}{
 		{
 			name:       "pure send: inputs exceed change",
 			myVtxos:    []clientTypes.Vtxo{vtxo(10_000), vtxo(5_000)},
 			vtxosToAdd: []clientTypes.Vtxo{vtxo(3_000)},
 			wantAmount: 12_000,
-			wantSent:   true,
+			wantType:   clientTypes.TxSent,
+			wantOk:     true,
 		},
 		{
-			name:        "boarding + vtxo spend in same round: boarding inflates vtxosToAdd beyond myVtxos",
+			name:        "boarding + vtxo spend in same round: boarding counts as input",
 			myVtxos:     []clientTypes.Vtxo{vtxo(1_000)},
 			boardingTxs: []clientTypes.Transaction{boarding(20_000)},
 			vtxosToAdd:  []clientTypes.Vtxo{vtxo(18_000)},
 			wantAmount:  3_000,
-			wantSent:    true,
+			wantType:    clientTypes.TxSent,
+			wantOk:      true,
 		},
 		{
-			name:       "totalIn equals totalOut: no TxSent recorded",
+			name:       "net receive: outputs exceed inputs (no underflow)",
+			myVtxos:    []clientTypes.Vtxo{vtxo(1_000)},
+			vtxosToAdd: []clientTypes.Vtxo{vtxo(9_000)},
+			wantAmount: 8_000,
+			wantType:   clientTypes.TxReceived,
+			wantOk:     true,
+		},
+		{
+			name:       "inputs equal outputs: nothing recorded",
 			myVtxos:    []clientTypes.Vtxo{vtxo(5_000)},
 			vtxosToAdd: []clientTypes.Vtxo{vtxo(5_000)},
 			wantAmount: 0,
-			wantSent:   false,
-		},
-		{
-			name:       "totalIn less than totalOut: no underflow, no TxSent",
-			myVtxos:    []clientTypes.Vtxo{vtxo(1_000)},
-			vtxosToAdd: []clientTypes.Vtxo{vtxo(9_000)},
-			wantAmount: 0,
-			wantSent:   false,
+			wantOk:     false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, ok := committedSentAmount(tc.myVtxos, tc.boardingTxs, tc.vtxosToAdd)
-			require.Equal(t, tc.wantSent, ok)
-			require.Equal(t, tc.wantAmount, got)
+			amount, txType, ok := committedNetAmount(tc.myVtxos, tc.boardingTxs, tc.vtxosToAdd)
+			require.Equal(t, tc.wantOk, ok)
+			require.Equal(t, tc.wantAmount, amount)
+			require.Equal(t, tc.wantType, txType)
 		})
 	}
 }
 
-func TestArkSentAmount(t *testing.T) {
+func TestArkNetAmount(t *testing.T) {
 	t.Parallel()
 
 	vtxo := func(amount uint64) clientTypes.Vtxo { return clientTypes.Vtxo{Amount: amount} }
@@ -72,44 +77,41 @@ func TestArkSentAmount(t *testing.T) {
 		myVtxos    []clientTypes.Vtxo
 		vtxosToAdd []clientTypes.Vtxo
 		wantAmount uint64
-		wantSent   bool
+		wantType   clientTypes.TxType
+		wantOk     bool
 	}{
 		{
 			name:       "pure send: inputs exceed change",
 			myVtxos:    []clientTypes.Vtxo{vtxo(10_000), vtxo(5_000)},
 			vtxosToAdd: []clientTypes.Vtxo{vtxo(3_000)},
 			wantAmount: 12_000,
-			wantSent:   true,
+			wantType:   clientTypes.TxSent,
+			wantOk:     true,
 		},
 		{
-			name:       "receive in same ark tx inflates vtxosToAdd beyond myVtxos: no underflow, no TxSent",
+			name:       "net receive in same ark tx: outputs exceed inputs (no underflow)",
 			myVtxos:    []clientTypes.Vtxo{vtxo(1_000)},
 			vtxosToAdd: []clientTypes.Vtxo{vtxo(9_000)},
-			wantAmount: 0,
-			wantSent:   false,
+			wantAmount: 8_000,
+			wantType:   clientTypes.TxReceived,
+			wantOk:     true,
 		},
 		{
-			name:       "totalIn equals totalOut: no TxSent recorded",
+			name:       "inputs equal outputs: nothing recorded",
 			myVtxos:    []clientTypes.Vtxo{vtxo(5_000)},
 			vtxosToAdd: []clientTypes.Vtxo{vtxo(5_000)},
 			wantAmount: 0,
-			wantSent:   false,
-		},
-		{
-			name:       "totalIn less than totalOut: no underflow, no TxSent",
-			myVtxos:    []clientTypes.Vtxo{vtxo(2_000)},
-			vtxosToAdd: []clientTypes.Vtxo{vtxo(8_000)},
-			wantAmount: 0,
-			wantSent:   false,
+			wantOk:     false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, ok := arkSentAmount(tc.myVtxos, tc.vtxosToAdd)
-			require.Equal(t, tc.wantSent, ok)
-			require.Equal(t, tc.wantAmount, got)
+			amount, txType, ok := arkNetAmount(tc.myVtxos, tc.vtxosToAdd)
+			require.Equal(t, tc.wantOk, ok)
+			require.Equal(t, tc.wantAmount, amount)
+			require.Equal(t, tc.wantType, txType)
 		})
 	}
 }

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCommittedNetAmount(t *testing.T) {
+func TestCommitmentTxNetAmount(t *testing.T) {
 	t.Parallel()
 
 	vtxo := func(amount uint64) clientTypes.Vtxo { return clientTypes.Vtxo{Amount: amount} }
@@ -67,7 +67,7 @@ func TestCommittedNetAmount(t *testing.T) {
 	}
 }
 
-func TestArkNetAmount(t *testing.T) {
+func TestArkTxNetAmount(t *testing.T) {
 	t.Parallel()
 
 	vtxo := func(amount uint64) clientTypes.Vtxo { return clientTypes.Vtxo{Amount: amount} }

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -59,7 +59,7 @@ func TestCommittedNetAmount(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			amount, txType, ok := committedNetAmount(tc.myVtxos, tc.boardingTxs, tc.vtxosToAdd)
+			amount, txType, ok := commitmentTxNetAmount(tc.myVtxos, tc.boardingTxs, tc.vtxosToAdd)
 			require.Equal(t, tc.wantOk, ok)
 			require.Equal(t, tc.wantAmount, amount)
 			require.Equal(t, tc.wantType, txType)
@@ -108,7 +108,7 @@ func TestArkNetAmount(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			amount, txType, ok := arkNetAmount(tc.myVtxos, tc.vtxosToAdd)
+			amount, txType, ok := arkTxNetAmount(tc.myVtxos, tc.vtxosToAdd)
 			require.Equal(t, tc.wantOk, ok)
 			require.Equal(t, tc.wantAmount, amount)
 			require.Equal(t, tc.wantType, txType)

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -7,6 +7,113 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCommittedSentAmount(t *testing.T) {
+	t.Parallel()
+
+	vtxo := func(amount uint64) clientTypes.Vtxo { return clientTypes.Vtxo{Amount: amount} }
+	boarding := func(amount uint64) clientTypes.Transaction { return clientTypes.Transaction{Amount: amount} }
+
+	tests := []struct {
+		name        string
+		myVtxos     []clientTypes.Vtxo
+		boardingTxs []clientTypes.Transaction
+		vtxosToAdd  []clientTypes.Vtxo
+		wantAmount  uint64
+		wantSent    bool
+	}{
+		{
+			name:       "pure send: inputs exceed change",
+			myVtxos:    []clientTypes.Vtxo{vtxo(10_000), vtxo(5_000)},
+			vtxosToAdd: []clientTypes.Vtxo{vtxo(3_000)},
+			wantAmount: 12_000,
+			wantSent:   true,
+		},
+		{
+			name:        "boarding + vtxo spend in same round: boarding inflates vtxosToAdd beyond myVtxos",
+			myVtxos:     []clientTypes.Vtxo{vtxo(1_000)},
+			boardingTxs: []clientTypes.Transaction{boarding(20_000)},
+			vtxosToAdd:  []clientTypes.Vtxo{vtxo(18_000)},
+			wantAmount:  3_000,
+			wantSent:    true,
+		},
+		{
+			name:       "totalIn equals totalOut: no TxSent recorded",
+			myVtxos:    []clientTypes.Vtxo{vtxo(5_000)},
+			vtxosToAdd: []clientTypes.Vtxo{vtxo(5_000)},
+			wantAmount: 0,
+			wantSent:   false,
+		},
+		{
+			name:       "totalIn less than totalOut: no underflow, no TxSent",
+			myVtxos:    []clientTypes.Vtxo{vtxo(1_000)},
+			vtxosToAdd: []clientTypes.Vtxo{vtxo(9_000)},
+			wantAmount: 0,
+			wantSent:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := committedSentAmount(tc.myVtxos, tc.boardingTxs, tc.vtxosToAdd)
+			require.Equal(t, tc.wantSent, ok)
+			require.Equal(t, tc.wantAmount, got)
+		})
+	}
+}
+
+func TestArkSentAmount(t *testing.T) {
+	t.Parallel()
+
+	vtxo := func(amount uint64) clientTypes.Vtxo { return clientTypes.Vtxo{Amount: amount} }
+
+	tests := []struct {
+		name       string
+		myVtxos    []clientTypes.Vtxo
+		vtxosToAdd []clientTypes.Vtxo
+		wantAmount uint64
+		wantSent   bool
+	}{
+		{
+			name:       "pure send: inputs exceed change",
+			myVtxos:    []clientTypes.Vtxo{vtxo(10_000), vtxo(5_000)},
+			vtxosToAdd: []clientTypes.Vtxo{vtxo(3_000)},
+			wantAmount: 12_000,
+			wantSent:   true,
+		},
+		{
+			name:       "receive in same ark tx inflates vtxosToAdd beyond myVtxos: no underflow, no TxSent",
+			myVtxos:    []clientTypes.Vtxo{vtxo(1_000)},
+			vtxosToAdd: []clientTypes.Vtxo{vtxo(9_000)},
+			wantAmount: 0,
+			wantSent:   false,
+		},
+		{
+			name:       "totalIn equals totalOut: no TxSent recorded",
+			myVtxos:    []clientTypes.Vtxo{vtxo(5_000)},
+			vtxosToAdd: []clientTypes.Vtxo{vtxo(5_000)},
+			wantAmount: 0,
+			wantSent:   false,
+		},
+		{
+			name:       "totalIn less than totalOut: no underflow, no TxSent",
+			myVtxos:    []clientTypes.Vtxo{vtxo(2_000)},
+			vtxosToAdd: []clientTypes.Vtxo{vtxo(8_000)},
+			wantAmount: 0,
+			wantSent:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := arkSentAmount(tc.myVtxos, tc.vtxosToAdd)
+			require.Equal(t, tc.wantSent, ok)
+			require.Equal(t, tc.wantAmount, got)
+		})
+	}
+}
+
 func TestGroupSpentVtxosByTx(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #170

- `handleCommitmentTx` computes the net sent amount by subtracting `vtxosToAdd` (our change outputs) from `myVtxos` (our spent inputs). Because both are `uint64`, if `vtxosToAdd > myVtxos` the result silently wraps to a huge number, recording a bogus `TxSent` entry.
- Added `pendingBoardingTxs` amounts to `totalIn` so boarding inputs are correctly counted alongside spent vtxos.
- Replaced the raw subtraction with a guarded `totalIn > totalOut` check before subtracting.

## Boarding scenario (root cause highlighted)

The invariant `myVtxos >= vtxosToAdd` assumed this branch always represents a pure send, but it breaks whenever boarding and a vtxo spend land in the same commitment tx:

- **`myVtxos`** — existing vtxos being spent (e.g. small)
- **`pendingBoardingTxs`** — on-chain boarding UTXOs being settled (potentially large)
- **`vtxosToAdd`** — all new vtxos issued to us, including the one created from the boarding input

So `vtxosToAdd` easily exceeds `myVtxos` alone, causing the underflow. The fix counts boarding amounts as part of `totalIn` so the net calculation reflects the full picture.

## Test plan

- [ ] Send vtxos in a round where no boarding occurs — `TxSent` amount is unchanged
- [ ] Board and spend vtxos in the same commitment tx — no underflow, `TxSent` reflects correct net amount
- [ ] Receive a payment in the same round as a vtxo spend — `totalIn <= totalOut`, no spurious `TxSent` recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction amount calculations for committed transactions with pending transactions. The system now correctly computes sent amounts by accounting for all input and output transactions, ensuring accurate financial reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/go-sdk/pull/172)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->