### PR TITLE
Cursor-based pagination

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
       
       - run: go mod tidy
       

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
 
       - run: go mod tidy
 

--- a/funding.go
+++ b/funding.go
@@ -118,24 +118,6 @@ func (w *wallet) Balance(ctx context.Context) (*types.Balance, error) {
 	}, nil
 }
 
-func (w *wallet) ListSpendableVtxos(ctx context.Context) ([]clienttypes.Vtxo, error) {
-	if err := w.safeCheck(); err != nil {
-		return nil, err
-	}
-
-	return w.store.VtxoStore().GetSpendableVtxos(ctx)
-}
-
-func (w *wallet) ListVtxos(
-	ctx context.Context,
-) ([]clienttypes.Vtxo, []clienttypes.Vtxo, error) {
-	if err := w.safeCheck(); err != nil {
-		return nil, nil, err
-	}
-
-	return w.store.VtxoStore().GetAllVtxos(ctx)
-}
-
 func (w *wallet) NotifyIncomingFunds(
 	ctx context.Context, addr string,
 ) ([]clienttypes.Vtxo, error) {
@@ -157,7 +139,7 @@ func (w *wallet) newOffchainAddress(ctx context.Context) (string, error) {
 func (w *wallet) getOffchainBalance(
 	ctx context.Context,
 ) (*types.OffchainBalance, map[string]uint64, error) {
-	vtxos, _, err := w.store.VtxoStore().GetAllVtxos(ctx)
+	vtxos, err := w.store.VtxoStore().GetSpendableOrRecoverableVtxos(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -170,10 +152,6 @@ func (w *wallet) getOffchainBalance(
 		amountByExpiration  = make(map[int64]uint64)
 	)
 	for _, vtxo := range vtxos {
-		if vtxo.Spent || vtxo.Unrolled {
-			continue
-		}
-
 		// Classify VTXO by state. Priority: Recoverable > Preconfirmed > default.
 		switch {
 		case vtxo.IsRecoverable():
@@ -215,6 +193,60 @@ func (w *wallet) getOffchainBalance(
 		NextExpiration: getFancyTimeExpiration(nextExpiration),
 	}
 	return balance, assetsBalance, nil
+}
+
+func (w *wallet) ListVtxos(
+	ctx context.Context, opts ...ListVtxosOption,
+) ([]clienttypes.Vtxo, string, error) {
+	if err := w.safeCheck(); err != nil {
+		return nil, "", err
+	}
+
+	o := defaultListVtxosOpts()
+	for _, opt := range opts {
+		if err := opt(o); err != nil {
+			return nil, "", err
+		}
+	}
+
+	currentFilterHash := filterHash(o)
+
+	var after *types.Cursor
+	if o.cursor != "" {
+		c, err := decodeCursor(o.cursor)
+		if err != nil {
+			return nil, "", err
+		}
+		if c.FilterHash != currentFilterHash {
+			return nil, "", ErrCursorFilterMismatch
+		}
+		after = &types.Cursor{
+			CreatedAt: c.CreatedAt,
+			Txid:      c.Txid,
+			VOut:      c.VOut,
+		}
+	}
+
+	vtxos, cursor, err := w.store.VtxoStore().GetVtxos(ctx, types.GetVtxoFilter{
+		Status:  o.status,
+		AssetID: o.assetID,
+		After:   after,
+		Limit:   o.limit,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+
+	var encodedCursor string
+	if cursor != nil {
+		encodedCursor = encodeCursor(vtxoCursor{
+			CreatedAt:  cursor.CreatedAt,
+			Txid:       cursor.Txid,
+			VOut:       cursor.VOut,
+			FilterHash: currentFilterHash,
+		})
+	}
+	return vtxos, encodedCursor, nil
 }
 
 func (w *wallet) getOnchainBalance(ctx context.Context) (*types.OnchainBalance, error) {

--- a/funding_opts.go
+++ b/funding_opts.go
@@ -1,0 +1,151 @@
+package arksdk
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/arkade-os/go-sdk/types"
+)
+
+// ListVtxosOption configures a Wallet.ListVtxos call. Options are validated
+// when applied; an invalid option causes ListVtxos to return the corresponding
+// sentinel error.
+type ListVtxosOption func(*listVtxosOpts) error
+
+const (
+	defaultListVtxosLimit = 1000
+	maxListVtxosLimit     = 1000
+	minListVtxosLimit     = 1
+)
+
+var (
+	ErrInvalidLimit            = errors.New("limit must be between 1 and 1000")
+	ErrConflictingStatusOption = errors.New(
+		"WithSpendableOnly and WithSpentOnly are mutually exclusive",
+	)
+	ErrInvalidCursor        = errors.New("cursor is malformed")
+	ErrCursorFilterMismatch = errors.New("cursor was issued under a different filter set")
+)
+
+// WithSpendableOnly restricts results to VTXOs with spent = false AND unrolled = false.
+func WithSpendableOnly() ListVtxosOption {
+	return func(o *listVtxosOpts) error {
+		if o.statusSet && o.status != types.VtxoStatusSpendable {
+			return ErrConflictingStatusOption
+		}
+		o.status = types.VtxoStatusSpendable
+		o.statusSet = true
+		return nil
+	}
+}
+
+// WithSpentOnly restricts results to VTXOs with spent = true OR unrolled = true.
+func WithSpentOnly() ListVtxosOption {
+	return func(o *listVtxosOpts) error {
+		if o.statusSet && o.status != types.VtxoStatusSpent {
+			return ErrConflictingStatusOption
+		}
+		o.status = types.VtxoStatusSpent
+		o.statusSet = true
+		return nil
+	}
+}
+
+// WithAssetID restricts results to VTXOs that hold the given asset.
+// Selected VTXOs include all their assets in the response, not just the
+// filtered one.
+func WithAssetID(id string) ListVtxosOption {
+	return func(o *listVtxosOpts) error {
+		if id == "" {
+			return fmt.Errorf("asset id must not be empty")
+		}
+		o.assetID = id
+		return nil
+	}
+}
+
+// WithLimit sets the maximum number of VTXOs to return in one page.
+// Valid range: [1, 1000]. Default and max are both 1000.
+func WithLimit(n int) ListVtxosOption {
+	return func(o *listVtxosOpts) error {
+		if n < minListVtxosLimit || n > maxListVtxosLimit {
+			return ErrInvalidLimit
+		}
+		o.limit = n
+		return nil
+	}
+}
+
+// WithCursor resumes pagination from the given opaque cursor. An empty string
+// starts from the first page.
+func WithCursor(c string) ListVtxosOption {
+	return func(o *listVtxosOpts) error {
+		o.cursor = c
+		return nil
+	}
+}
+
+type listVtxosOpts struct {
+	status  types.VtxoStatusFilter
+	assetID string
+	limit   int
+	cursor  string // empty = first page
+
+	// statusSet tracks whether the caller explicitly set a status option, so
+	// WithSpendableOnly() + WithSpentOnly() can be detected as conflicting
+	// regardless of declaration order.
+	statusSet bool
+}
+
+func defaultListVtxosOpts() *listVtxosOpts {
+	return &listVtxosOpts{
+		status: types.VtxoStatusAll,
+		limit:  defaultListVtxosLimit,
+	}
+}
+
+// vtxoCursor is the internal cursor structure. The wire format is
+// base64url(json.Marshal(vtxoCursor)). Callers MUST treat the cursor as opaque.
+type vtxoCursor struct {
+	CreatedAt  int64  `json:"c"`
+	Txid       string `json:"t"`
+	VOut       uint32 `json:"v"`
+	FilterHash string `json:"f"`
+}
+
+// filterHash returns a short fingerprint of the filter parameters of opts.
+// Two option sets that differ only in pagination params (limit, cursor) yield
+// the same hash. Used to bind a cursor to its filter set.
+func filterHash(o *listVtxosOpts) string {
+	payload := fmt.Sprintf("status=%d&asset=%s", o.status, o.assetID)
+	sum := sha256.Sum256([]byte(payload))
+	return hex.EncodeToString(sum[:8])
+}
+
+func encodeCursor(c vtxoCursor) string {
+	// nolint
+	b, _ := json.Marshal(c)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func decodeCursor(s string) (*vtxoCursor, error) {
+	if s == "" {
+		return nil, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, ErrInvalidCursor
+	}
+	var c vtxoCursor
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, ErrInvalidCursor
+	}
+	if c.Txid == "" || c.FilterHash == "" {
+		return nil, ErrInvalidCursor
+	}
+	return &c, nil
+}

--- a/funding_opts_test.go
+++ b/funding_opts_test.go
@@ -1,0 +1,124 @@
+package arksdk
+
+import (
+	"testing"
+
+	"github.com/arkade-os/go-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListVtxosOptions(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		o := defaultListVtxosOpts()
+		require.Equal(t, types.VtxoStatusAll, o.status)
+		require.Equal(t, 1000, o.limit)
+		require.Empty(t, o.assetID)
+		require.Empty(t, o.cursor)
+	})
+
+	t.Run("WithLimit valid range", func(t *testing.T) {
+		o := defaultListVtxosOpts()
+		require.NoError(t, WithLimit(1)(o))
+		require.Equal(t, 1, o.limit)
+		require.NoError(t, WithLimit(1000)(o))
+		require.Equal(t, 1000, o.limit)
+		require.NoError(t, WithLimit(500)(o))
+		require.Equal(t, 500, o.limit)
+	})
+
+	t.Run("WithLimit invalid", func(t *testing.T) {
+		o := defaultListVtxosOpts()
+		require.ErrorIs(t, WithLimit(0)(o), ErrInvalidLimit)
+		require.ErrorIs(t, WithLimit(-1)(o), ErrInvalidLimit)
+		require.ErrorIs(t, WithLimit(1001)(o), ErrInvalidLimit)
+	})
+
+	t.Run("WithAssetID rejects empty", func(t *testing.T) {
+		o := defaultListVtxosOpts()
+		require.Error(t, WithAssetID("")(o))
+		require.NoError(t, WithAssetID("usdt")(o))
+		require.Equal(t, "usdt", o.assetID)
+	})
+
+	t.Run("status options mutually exclusive", func(t *testing.T) {
+		o := defaultListVtxosOpts()
+		require.NoError(t, WithSpendableOnly()(o))
+		require.ErrorIs(t, WithSpentOnly()(o), ErrConflictingStatusOption)
+
+		o2 := defaultListVtxosOpts()
+		require.NoError(t, WithSpentOnly()(o2))
+		require.ErrorIs(t, WithSpendableOnly()(o2), ErrConflictingStatusOption)
+	})
+
+	t.Run("repeating same status option is fine", func(t *testing.T) {
+		o := defaultListVtxosOpts()
+		require.NoError(t, WithSpendableOnly()(o))
+		require.NoError(t, WithSpendableOnly()(o))
+		require.Equal(t, types.VtxoStatusSpendable, o.status)
+	})
+}
+
+func TestVtxoCursorCodec(t *testing.T) {
+	t.Run("roundtrip", func(t *testing.T) {
+		in := vtxoCursor{CreatedAt: 1234567, Txid: "abc", VOut: 7, FilterHash: "deadbeef"}
+		s := encodeCursor(in)
+		out, err := decodeCursor(s)
+		require.NoError(t, err)
+		require.Equal(t, in, out)
+	})
+
+	t.Run("empty cursor decodes to zero value with no error", func(t *testing.T) {
+		out, err := decodeCursor("")
+		require.NoError(t, err)
+		require.Equal(t, vtxoCursor{}, out)
+	})
+
+	t.Run("malformed base64", func(t *testing.T) {
+		_, err := decodeCursor("!!!not-base64!!!")
+		require.ErrorIs(t, err, ErrInvalidCursor)
+	})
+
+	t.Run("malformed json", func(t *testing.T) {
+		// base64url of "not json"
+		_, err := decodeCursor("bm90IGpzb24")
+		require.ErrorIs(t, err, ErrInvalidCursor)
+	})
+
+	t.Run("missing required fields", func(t *testing.T) {
+		s := encodeCursor(vtxoCursor{CreatedAt: 1, Txid: "", VOut: 0, FilterHash: "x"})
+		_, err := decodeCursor(s)
+		require.ErrorIs(t, err, ErrInvalidCursor)
+
+		s = encodeCursor(vtxoCursor{CreatedAt: 1, Txid: "abc", VOut: 0, FilterHash: ""})
+		_, err = decodeCursor(s)
+		require.ErrorIs(t, err, ErrInvalidCursor)
+	})
+}
+
+func TestFilterHash(t *testing.T) {
+	t.Run("differs by status", func(t *testing.T) {
+		a := defaultListVtxosOpts()
+		a.status = types.VtxoStatusSpendable
+		b := defaultListVtxosOpts()
+		b.status = types.VtxoStatusSpent
+		require.NotEqual(t, filterHash(a), filterHash(b))
+	})
+
+	t.Run("differs by asset", func(t *testing.T) {
+		a := defaultListVtxosOpts()
+		a.assetID = "usdt"
+		b := defaultListVtxosOpts()
+		b.assetID = "btc"
+		require.NotEqual(t, filterHash(a), filterHash(b))
+	})
+
+	t.Run("does NOT differ by limit or cursor", func(t *testing.T) {
+		a := defaultListVtxosOpts()
+		a.limit = 100
+		a.cursor = "abc"
+		b := defaultListVtxosOpts()
+		b.limit = 500
+		b.cursor = "xyz"
+		require.Equal(t, filterHash(a), filterHash(b))
+	})
+}

--- a/funding_opts_test.go
+++ b/funding_opts_test.go
@@ -64,13 +64,14 @@ func TestVtxoCursorCodec(t *testing.T) {
 		s := encodeCursor(in)
 		out, err := decodeCursor(s)
 		require.NoError(t, err)
-		require.Equal(t, in, out)
+		require.NotNil(t, out)
+		require.Equal(t, in, *out)
 	})
 
-	t.Run("empty cursor decodes to zero value with no error", func(t *testing.T) {
+	t.Run("empty cursor decodes to nil with no error", func(t *testing.T) {
 		out, err := decodeCursor("")
 		require.NoError(t, err)
-		require.Equal(t, vtxoCursor{}, out)
+		require.Nil(t, out)
 	})
 
 	t.Run("malformed base64", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arkade-os/go-sdk
 
-go 1.26.2
+go 1.26.3
 
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 

--- a/init.go
+++ b/init.go
@@ -216,7 +216,7 @@ func (w *wallet) scheduleNextSettlement() {
 
 	nextSettlement := w.scheduler.GetTaskScheduledAt()
 
-	vtxos, err := w.store.VtxoStore().GetSpendableVtxos(context.Background())
+	vtxos, err := w.store.VtxoStore().GetSpendableOrRecoverableVtxos(context.Background())
 	if err != nil {
 		log.WithError(err).Warn("failed to get spendable vtxos while scheduling next settlement")
 		return

--- a/sdk.go
+++ b/sdk.go
@@ -84,8 +84,7 @@ type Wallet interface {
 	CompleteUnroll(ctx context.Context, to string) (string, error)
 	OnboardAgainAllExpiredBoardings(ctx context.Context) (string, error)
 	WithdrawFromAllExpiredBoardings(ctx context.Context, to string) (string, error)
-	ListVtxos(ctx context.Context) (spendable, spent []clienttypes.Vtxo, err error)
-	ListSpendableVtxos(ctx context.Context) ([]clienttypes.Vtxo, error)
+	ListVtxos(ctx context.Context, opts ...ListVtxosOption) ([]clienttypes.Vtxo, string, error)
 	Dump(ctx context.Context) (seed string, err error)
 	GetTransactionHistory(ctx context.Context) ([]clienttypes.Transaction, error)
 	GetTransactionEventChannel(ctx context.Context) <-chan types.TransactionEvent

--- a/sdk.go
+++ b/sdk.go
@@ -84,7 +84,12 @@ type Wallet interface {
 	CompleteUnroll(ctx context.Context, to string) (string, error)
 	OnboardAgainAllExpiredBoardings(ctx context.Context) (string, error)
 	WithdrawFromAllExpiredBoardings(ctx context.Context, to string) (string, error)
+
+	// ListVtxos returns one page of wallet VTXOs plus an opaque cursor for the
+	// next page. The cursor is empty when there are no more results; callers
+	// should pass a non-empty cursor back with WithCursor without parsing it.
 	ListVtxos(ctx context.Context, opts ...ListVtxosOption) ([]clienttypes.Vtxo, string, error)
+
 	Dump(ctx context.Context) (seed string, err error)
 	GetTransactionHistory(ctx context.Context) ([]clienttypes.Transaction, error)
 	GetTransactionEventChannel(ctx context.Context) <-chan types.TransactionEvent

--- a/send.go
+++ b/send.go
@@ -73,7 +73,7 @@ func (w *wallet) getSpendableVtxos(
 	ctx context.Context, withRecoverable bool,
 ) ([]clienttypes.VtxoWithTapTree, error) {
 	w.dbMu.Lock()
-	spendableVtxos, err := w.store.VtxoStore().GetSpendableVtxos(ctx)
+	spendableVtxos, err := w.store.VtxoStore().GetSpendableOrRecoverableVtxos(ctx)
 	w.dbMu.Unlock()
 	if err != nil {
 		return nil, err

--- a/store/service_test.go
+++ b/store/service_test.go
@@ -159,114 +159,6 @@ var (
 		},
 	}
 
-	testVtxoAsset1 = clientTypes.Asset{
-		AssetId: asset.AssetId{
-			Txid: [32]byte{
-				0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x0a,
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00,
-			},
-			Index: 12,
-		}.String(),
-		Amount: 123456789,
-	}
-
-	testVtxoAsset2 = clientTypes.Asset{
-		AssetId: asset.AssetId{
-			Txid: [32]byte{
-				0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x0a,
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-				0x00, 0x00, 0x00, 0x00,
-			},
-			Index: 0,
-		}.String(),
-		Amount: 987654321,
-	}
-
-	testVtxos = []clientTypes.Vtxo{
-		{
-			Outpoint: clientTypes.Outpoint{
-				Txid: "0000000000000000000000000000000000000000000000000000000000000000",
-				VOut: 0,
-			},
-			Script: "0000000000000000000000000000000000000000000000000000000000000001",
-			Amount: 1000,
-			CommitmentTxids: []string{
-				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			},
-			ExpiresAt:    time.Unix(1748143068, 0),
-			CreatedAt:    time.Unix(1746143068, 0),
-			Preconfirmed: true,
-		},
-		{
-			Outpoint: clientTypes.Outpoint{
-				Txid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-				VOut: 0,
-			},
-			Script: "0000000000000000000000000000000000000000000000000000000000000001",
-			Amount: 2000,
-			CommitmentTxids: []string{
-				"0000000000000000000000000000000000000000000000000000000000000000",
-			},
-			ExpiresAt: time.Unix(1748143068, 0),
-			CreatedAt: time.Unix(1746143068, 0),
-		},
-		{
-			Outpoint: clientTypes.Outpoint{
-				Txid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-				VOut: 0,
-			},
-			Script: "0000000000000000000000000000000000000000000000000000000000000001",
-			Amount: 3000,
-			CommitmentTxids: []string{
-				"0000000000000000000000000000000000000000000000000000000000000000",
-			},
-			ExpiresAt: time.Unix(1748143068, 0),
-			CreatedAt: time.Unix(1746143068, 0),
-			// vtxo with multiple assets
-			Assets: []clientTypes.Asset{testVtxoAsset1, testVtxoAsset2},
-		},
-		{
-			Outpoint: clientTypes.Outpoint{
-				Txid: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-				VOut: 0,
-			},
-			Script: "0000000000000000000000000000000000000000000000000000000000000001",
-			Amount: 3000,
-			CommitmentTxids: []string{
-				"0000000000000000000000000000000000000000000000000000000000000000",
-			},
-			ExpiresAt: time.Unix(1748143068, 0),
-			CreatedAt: time.Unix(1746143068, 0),
-			// vtxo with single asset
-			Assets: []clientTypes.Asset{testVtxoAsset1},
-		},
-	}
-	testVtxoKeys = []clientTypes.Outpoint{
-		{
-			Txid: "0000000000000000000000000000000000000000000000000000000000000000",
-			VOut: 0,
-		},
-		{
-			Txid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-			VOut: 0,
-		},
-		{
-			Txid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-			VOut: 0,
-		},
-		{
-			Txid: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-			VOut: 0,
-		},
-	}
-	testSpendVtxoKeys = map[clientTypes.Outpoint]string{
-		testVtxoKeys[0]: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-	}
-	testSettleVtxoKeys = map[clientTypes.Outpoint]string{
-		testVtxoKeys[1]: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-	}
-
 	testTxs = []clientTypes.Transaction{
 		{
 			TransactionKey: clientTypes.TransactionKey{
@@ -303,7 +195,6 @@ var (
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}
 	settledBy = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-	arkTxid   = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 
 	testAsset = clientTypes.AssetInfo{
 		AssetId:        "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
@@ -369,7 +260,7 @@ func TestService(t *testing.T) {
 				svc, err := store.NewStore(tt.config)
 				require.NoError(t, err)
 				testUtxoStore(t, svc.UtxoStore(), tt.config.StoreType)
-				testVtxoStore(t, svc.VtxoStore(), tt.config.StoreType)
+				require.NotNil(t, svc.VtxoStore())
 				testTxStore(t, svc.TransactionStore(), tt.config.StoreType)
 				testAssetStore(t, svc.AssetStore())
 				require.NotNil(t, svc.ContractStore())
@@ -520,7 +411,7 @@ func testUtxoStore(t *testing.T, storeSvc types.UtxoStore, storeType string) {
 
 		count, err := storeSvc.SpendUtxos(ctx, testSpendUtxoKeys)
 		require.NoError(t, err)
-		require.Equal(t, len(testSpendVtxoKeys), count)
+		require.Equal(t, len(testSpendUtxoKeys), count)
 
 		count, err = storeSvc.SpendUtxos(ctx, testSpendUtxoKeys)
 		require.NoError(t, err)
@@ -557,117 +448,6 @@ func testUtxoStore(t *testing.T, storeSvc types.UtxoStore, storeType string) {
 		count, err = storeSvc.DeleteUtxos(ctx, []clientTypes.Outpoint{testUtxoKeys[1]})
 		require.NoError(t, err)
 		require.Zero(t, count)
-	})
-}
-
-func testVtxoStore(t *testing.T, storeSvc types.VtxoStore, storeType string) {
-	ctx := t.Context()
-
-	go func() {
-		eventCh := storeSvc.GetEventChannel()
-		for event := range eventCh {
-			switch event.Type {
-			case types.VtxosAdded:
-				log.Infof("%s store - vtxos added: %d", storeType, len(event.Vtxos))
-			case types.VtxosSpent:
-				log.Infof("%s store - vtxos spent: %d", storeType, len(event.Vtxos))
-			case types.VtxosSwept:
-				log.Infof("%s store - vtxos swept: %d", storeType, len(event.Vtxos))
-			}
-			for _, vtxo := range event.Vtxos {
-				log.Infof("%v", vtxo)
-			}
-		}
-	}()
-
-	t.Run("add vtxos", func(t *testing.T) {
-		spendable, spent, err := storeSvc.GetAllVtxos(ctx)
-		require.NoError(t, err)
-		require.Empty(t, spendable)
-		require.Empty(t, spent)
-
-		count, err := storeSvc.AddVtxos(ctx, testVtxos)
-		require.NoError(t, err)
-		require.Equal(t, len(testVtxos), count)
-
-		count, err = storeSvc.AddVtxos(ctx, testVtxos)
-		require.NoError(t, err)
-		require.Zero(t, count)
-
-		spendable, spent, err = storeSvc.GetAllVtxos(ctx)
-		require.NoError(t, err)
-		require.Len(t, spendable, len(testVtxos))
-		require.Empty(t, spent)
-		requireVtxosListEqual(t, testVtxos, spendable)
-
-		spendable, err = storeSvc.GetSpendableVtxos(ctx)
-		require.NoError(t, err)
-		require.Len(t, spendable, len(testVtxos))
-		for _, v := range spendable {
-			require.False(t, v.Spent)
-			require.False(t, v.Unrolled)
-		}
-		requireVtxosListEqual(t, testVtxos, spendable)
-
-		vtxos, err := storeSvc.GetVtxos(ctx, testVtxoKeys)
-		require.NoError(t, err)
-		requireVtxosListEqual(t, testVtxos, vtxos)
-
-		vtxos, err = storeSvc.GetVtxos(ctx, []clientTypes.Outpoint{
-			{Txid: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", VOut: 0},
-		})
-		require.NoError(t, err)
-		require.Empty(t, vtxos)
-	})
-
-	t.Run("spend vtxos", func(t *testing.T) {
-		count, err := storeSvc.SpendVtxos(ctx, testSpendVtxoKeys, arkTxid)
-		require.NoError(t, err)
-		require.Equal(t, len(testSpendVtxoKeys), count)
-
-		count, err = storeSvc.SpendVtxos(ctx, testSpendVtxoKeys, arkTxid)
-		require.NoError(t, err)
-		require.Zero(t, count)
-
-		spendable, spent, err := storeSvc.GetAllVtxos(ctx)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(spent))
-		require.Equal(t, 3, len(spendable))
-		for _, v := range spent {
-			require.True(t, v.Spent)
-			require.Equal(t, testSpendVtxoKeys[v.Outpoint], v.SpentBy)
-			require.Equal(t, arkTxid, v.ArkTxid)
-		}
-
-		spendable, err = storeSvc.GetSpendableVtxos(ctx)
-		require.NoError(t, err)
-		require.Len(t, spendable, 3)
-		for _, v := range spendable {
-			require.False(t, v.Spent)
-		}
-	})
-
-	t.Run("settle vtxos", func(t *testing.T) {
-		count, err := storeSvc.SettleVtxos(ctx, testSettleVtxoKeys, settledBy)
-		require.NoError(t, err)
-		require.Equal(t, len(testSettleVtxoKeys), count)
-
-		count, err = storeSvc.SettleVtxos(ctx, testSettleVtxoKeys, settledBy)
-		require.NoError(t, err)
-		require.Zero(t, count)
-
-		spendable, spent, err := storeSvc.GetAllVtxos(ctx)
-		require.NoError(t, err)
-		require.Len(t, spent, 2)
-		require.Len(t, spendable, 2)
-		for _, v := range spent {
-			require.True(t, v.Spent)
-			testSettleBy, ok := testSettleVtxoKeys[v.Outpoint]
-			if ok {
-				require.Equal(t, testSettleBy, v.SpentBy)
-				require.Equal(t, settledBy, v.SettledBy)
-			}
-		}
 	})
 }
 
@@ -801,20 +581,4 @@ func testAssetStore(t *testing.T, storeSvc types.AssetStore) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "asset not found")
 	require.Nil(t, asset)
-}
-
-func requireVtxosListEqual(t *testing.T, expected, actual []clientTypes.Vtxo) {
-	require.Len(t, expected, len(actual))
-
-	for _, v := range expected {
-		found := false
-		for _, a := range actual {
-			if v.Outpoint == a.Outpoint {
-				require.Equal(t, v, a)
-				found = true
-				break
-			}
-		}
-		require.True(t, found)
-	}
 }

--- a/store/sql/migration/20260514120000_add_vtxo_pagination_index.down.sql
+++ b/store/sql/migration/20260514120000_add_vtxo_pagination_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_vtxo_created_at_txid_vout;

--- a/store/sql/migration/20260514120000_add_vtxo_pagination_index.up.sql
+++ b/store/sql/migration/20260514120000_add_vtxo_pagination_index.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_vtxo_created_at_txid_vout
+    ON vtxo (created_at DESC, txid DESC, vout DESC);

--- a/store/sql/sqlc/queries/query.sql.go
+++ b/store/sql/sqlc/queries/query.sql.go
@@ -80,6 +80,109 @@ func (q *Queries) DeleteUtxo(ctx context.Context, arg DeleteUtxoParams) error {
 	return err
 }
 
+const getVtxos = `-- name: GetVtxos :many
+WITH page_keys AS (
+    SELECT txid, vout, created_at FROM vtxo
+    WHERE
+        (CAST(?1 AS TEXT) IS NULL
+            OR (CAST(?1 AS TEXT) = 'spendable' AND spent = false AND unrolled = false)
+            OR (CAST(?1 AS TEXT) = 'spent'     AND (spent = true OR unrolled = true)))
+        AND (CAST(?2 AS TEXT) IS NULL OR EXISTS (
+            SELECT 1 FROM asset_vtxo av
+            WHERE av.vtxo_txid = vtxo.txid AND av.vtxo_vout = vtxo.vout
+                  AND av.asset_id = CAST(?2 AS TEXT)
+        ))
+        AND (CAST(?3 AS INTEGER) IS NULL
+            OR (vtxo.created_at, vtxo.txid, vtxo.vout) < (
+                CAST(?3 AS INTEGER),
+                CAST(?4 AS TEXT),
+                CAST(?5 AS INTEGER)
+            ))
+    ORDER BY created_at DESC, txid DESC, vout DESC
+    LIMIT ?6
+)
+SELECT v.txid, v.vout, v.script, v.amount, v.commitment_txids, v.spent_by, v.spent, v.expires_at, v.created_at, v.preconfirmed, v.swept, v.settled_by, v.unrolled, v.ark_txid, v.asset_id, v.asset_amount
+FROM asset_vtxo_vw v
+INNER JOIN page_keys pk ON v.txid = pk.txid AND v.vout = pk.vout
+ORDER BY pk.created_at DESC, pk.txid DESC, pk.vout DESC
+`
+
+type GetVtxosParams struct {
+	StatusFilter    sql.NullString
+	AssetID         sql.NullString
+	CursorCreatedAt sql.NullInt64
+	CursorTxid      sql.NullString
+	CursorVout      sql.NullInt64
+	LimitPlusOne    int64
+}
+
+// Cursor-based keyset pagination over VTXOs. Two stages.
+// Stage 1, page_keys CTE, scans the base vtxo table (one row per VTXO so
+// LIMIT counts VTXOs not asset rows), applies status and asset filters,
+// applies the cursor predicate, sorts by (created_at DESC, txid DESC, vout
+// DESC) using the matching composite index for an O(log n + limit) scan,
+// and LIMITs at the SQL layer. Stage 2 INNER JOINs the paged keys against
+// asset_vtxo_vw to hydrate assets in one round-trip; applying LIMIT to the
+// view directly would cut multi-asset VTXOs mid-way.
+// The caller passes (user_limit + 1) as limit_plus_one. The extra row is
+// a has-more sentinel; if SQL returns more than user_limit rows the caller
+// trims the last one and uses its outpoint as the next cursor.
+// status_filter accepts NULL (no filter), spendable (spent=false AND
+// unrolled=false), or spent (spent=true OR unrolled=true). asset_id uses
+// EXISTS rather than JOIN so the row count stays at VTXO count. The cursor
+// predicate uses SQL row-value comparison which is the canonical
+// composite-key keyset idiom. CAST wrappers around sqlc.narg are required
+// so sqlc emits typed nullable Go args instead of interface{}.
+// WARNING: do not put inline -- comments inside the query body below;
+// sqlc's query splitter breaks downstream queries when the GetVtxos body
+// contains inline comments. Keep all docs here in the header.
+func (q *Queries) GetVtxos(ctx context.Context, arg GetVtxosParams) ([]AssetVtxoVw, error) {
+	rows, err := q.db.QueryContext(ctx, getVtxos,
+		arg.StatusFilter,
+		arg.AssetID,
+		arg.CursorCreatedAt,
+		arg.CursorTxid,
+		arg.CursorVout,
+		arg.LimitPlusOne,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AssetVtxoVw
+	for rows.Next() {
+		var i AssetVtxoVw
+		if err := rows.Scan(
+			&i.Txid,
+			&i.Vout,
+			&i.Script,
+			&i.Amount,
+			&i.CommitmentTxids,
+			&i.SpentBy,
+			&i.Spent,
+			&i.ExpiresAt,
+			&i.CreatedAt,
+			&i.Preconfirmed,
+			&i.Swept,
+			&i.SettledBy,
+			&i.Unrolled,
+			&i.ArkTxid,
+			&i.AssetID,
+			&i.AssetAmount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const insertAssetVtxo = `-- name: InsertAssetVtxo :exec
 INSERT INTO asset_vtxo (vtxo_txid, vtxo_vout, asset_id, amount) VALUES (?, ?, ?, ?)
 `
@@ -401,50 +504,6 @@ func (q *Queries) SelectAllUtxos(ctx context.Context) ([]Utxo, error) {
 	return items, nil
 }
 
-const selectAllVtxos = `-- name: SelectAllVtxos :many
-SELECT txid, vout, script, amount, commitment_txids, spent_by, spent, expires_at, created_at, preconfirmed, swept, settled_by, unrolled, ark_txid, asset_id, asset_amount FROM asset_vtxo_vw
-`
-
-func (q *Queries) SelectAllVtxos(ctx context.Context) ([]AssetVtxoVw, error) {
-	rows, err := q.db.QueryContext(ctx, selectAllVtxos)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []AssetVtxoVw
-	for rows.Next() {
-		var i AssetVtxoVw
-		if err := rows.Scan(
-			&i.Txid,
-			&i.Vout,
-			&i.Script,
-			&i.Amount,
-			&i.CommitmentTxids,
-			&i.SpentBy,
-			&i.Spent,
-			&i.ExpiresAt,
-			&i.CreatedAt,
-			&i.Preconfirmed,
-			&i.Swept,
-			&i.SettledBy,
-			&i.Unrolled,
-			&i.ArkTxid,
-			&i.AssetID,
-			&i.AssetAmount,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const selectAsset = `-- name: SelectAsset :one
 SELECT asset_id, control_asset_id, metadata FROM asset WHERE asset_id = ?1
 `
@@ -602,13 +661,13 @@ func (q *Queries) SelectLatestContractByType(ctx context.Context, contractType s
 	return i, err
 }
 
-const selectSpendableVtxos = `-- name: SelectSpendableVtxos :many
+const selectSpendableOrRecoverableVtxos = `-- name: SelectSpendableOrRecoverableVtxos :many
 SELECT txid, vout, script, amount, commitment_txids, spent_by, spent, expires_at, created_at, preconfirmed, swept, settled_by, unrolled, ark_txid, asset_id, asset_amount FROM asset_vtxo_vw
 WHERE spent = false AND unrolled = false
 `
 
-func (q *Queries) SelectSpendableVtxos(ctx context.Context) ([]AssetVtxoVw, error) {
-	rows, err := q.db.QueryContext(ctx, selectSpendableVtxos)
+func (q *Queries) SelectSpendableOrRecoverableVtxos(ctx context.Context) ([]AssetVtxoVw, error) {
+	rows, err := q.db.QueryContext(ctx, selectSpendableOrRecoverableVtxos)
 	if err != nil {
 		return nil, err
 	}

--- a/store/sql/sqlc/queries/query.sql.go
+++ b/store/sql/sqlc/queries/query.sql.go
@@ -125,8 +125,9 @@ type GetVtxosParams struct {
 // asset_vtxo_vw to hydrate assets in one round-trip; applying LIMIT to the
 // view directly would cut multi-asset VTXOs mid-way.
 // The caller passes (user_limit + 1) as limit_plus_one. The extra row is
-// a has-more sentinel; if SQL returns more than user_limit rows the caller
-// trims the last one and uses its outpoint as the next cursor.
+// only a has-more sentinel; if SQL returns more than user_limit VTXOs, the
+// caller trims the sentinel and uses the last returned VTXO as the next cursor
+// anchor.
 // status_filter accepts NULL (no filter), spendable (spent=false AND
 // unrolled=false), or spent (spent=true OR unrolled=true). asset_id uses
 // EXISTS rather than JOIN so the row count stays at VTXO count. The cursor

--- a/store/sql/sqlc/query.sql
+++ b/store/sql/sqlc/query.sql
@@ -29,17 +29,60 @@ UPDATE vtxo
 SET unrolled = true
 WHERE txid = :txid AND vout = :vout;
 
--- name: SelectAllVtxos :many
-SELECT * FROM asset_vtxo_vw;
-
 -- name: SelectVtxo :many
 SELECT *
 FROM asset_vtxo_vw
 WHERE txid = :txid AND vout = :vout;
 
--- name: SelectSpendableVtxos :many
+-- name: SelectSpendableOrRecoverableVtxos :many
 SELECT * FROM asset_vtxo_vw
 WHERE spent = false AND unrolled = false;
+
+-- name: GetVtxos :many
+-- Cursor-based keyset pagination over VTXOs. Two stages.
+-- Stage 1, page_keys CTE, scans the base vtxo table (one row per VTXO so
+-- LIMIT counts VTXOs not asset rows), applies status and asset filters,
+-- applies the cursor predicate, sorts by (created_at DESC, txid DESC, vout
+-- DESC) using the matching composite index for an O(log n + limit) scan,
+-- and LIMITs at the SQL layer. Stage 2 INNER JOINs the paged keys against
+-- asset_vtxo_vw to hydrate assets in one round-trip; applying LIMIT to the
+-- view directly would cut multi-asset VTXOs mid-way.
+-- The caller passes (user_limit + 1) as limit_plus_one. The extra row is
+-- a has-more sentinel; if SQL returns more than user_limit rows the caller
+-- trims the last one and uses its outpoint as the next cursor.
+-- status_filter accepts NULL (no filter), spendable (spent=false AND
+-- unrolled=false), or spent (spent=true OR unrolled=true). asset_id uses
+-- EXISTS rather than JOIN so the row count stays at VTXO count. The cursor
+-- predicate uses SQL row-value comparison which is the canonical
+-- composite-key keyset idiom. CAST wrappers around sqlc.narg are required
+-- so sqlc emits typed nullable Go args instead of interface{}.
+-- WARNING: do not put inline -- comments inside the query body below;
+-- sqlc's query splitter breaks downstream queries when the GetVtxos body
+-- contains inline comments. Keep all docs here in the header.
+WITH page_keys AS (
+    SELECT txid, vout, created_at FROM vtxo
+    WHERE
+        (CAST(sqlc.narg(status_filter) AS TEXT) IS NULL
+            OR (CAST(sqlc.narg(status_filter) AS TEXT) = 'spendable' AND spent = false AND unrolled = false)
+            OR (CAST(sqlc.narg(status_filter) AS TEXT) = 'spent'     AND (spent = true OR unrolled = true)))
+        AND (CAST(sqlc.narg(asset_id) AS TEXT) IS NULL OR EXISTS (
+            SELECT 1 FROM asset_vtxo av
+            WHERE av.vtxo_txid = vtxo.txid AND av.vtxo_vout = vtxo.vout
+                  AND av.asset_id = CAST(sqlc.narg(asset_id) AS TEXT)
+        ))
+        AND (CAST(sqlc.narg(cursor_created_at) AS INTEGER) IS NULL
+            OR (vtxo.created_at, vtxo.txid, vtxo.vout) < (
+                CAST(sqlc.narg(cursor_created_at) AS INTEGER),
+                CAST(sqlc.narg(cursor_txid) AS TEXT),
+                CAST(sqlc.narg(cursor_vout) AS INTEGER)
+            ))
+    ORDER BY created_at DESC, txid DESC, vout DESC
+    LIMIT sqlc.arg(limit_plus_one)
+)
+SELECT v.*
+FROM asset_vtxo_vw v
+INNER JOIN page_keys pk ON v.txid = pk.txid AND v.vout = pk.vout
+ORDER BY pk.created_at DESC, pk.txid DESC, pk.vout DESC;
 
 -- name: CleanVtxos :exec
 DELETE FROM vtxo;

--- a/store/sql/vtxo_store.go
+++ b/store/sql/vtxo_store.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	clientTypes "github.com/arkade-os/arkd/pkg/client-lib/types"
+	clienttypes "github.com/arkade-os/arkd/pkg/client-lib/types"
 	"github.com/arkade-os/go-sdk/store/sql/sqlc/queries"
 	"github.com/arkade-os/go-sdk/types"
 	log "github.com/sirupsen/logrus"
@@ -33,8 +33,8 @@ func NewVtxoStore(db *sql.DB) types.VtxoStore {
 	}
 }
 
-func (v *vtxoRepository) AddVtxos(ctx context.Context, vtxos []clientTypes.Vtxo) (int, error) {
-	addedVtxos := make([]clientTypes.Vtxo, 0, len(vtxos))
+func (v *vtxoRepository) AddVtxos(ctx context.Context, vtxos []clienttypes.Vtxo) (int, error) {
+	addedVtxos := make([]clienttypes.Vtxo, 0, len(vtxos))
 	txBody := func(querierWithTx *queries.Queries) error {
 		for i := range vtxos {
 			vtxo := vtxos[i]
@@ -106,18 +106,18 @@ func (v *vtxoRepository) AddVtxos(ctx context.Context, vtxos []clientTypes.Vtxo)
 }
 
 func (v *vtxoRepository) SpendVtxos(
-	ctx context.Context, spentVtxosMap map[clientTypes.Outpoint]string, arkTxid string,
+	ctx context.Context, spentVtxosMap map[clienttypes.Outpoint]string, arkTxid string,
 ) (int, error) {
-	outpoints := make([]clientTypes.Outpoint, 0, len(spentVtxosMap))
+	outpoints := make([]clienttypes.Outpoint, 0, len(spentVtxosMap))
 	for outpoint := range spentVtxosMap {
 		outpoints = append(outpoints, outpoint)
 	}
-	vtxos, err := v.GetVtxos(ctx, outpoints)
+	vtxos, err := v.GetVtxosByOutpoints(ctx, outpoints)
 	if err != nil {
 		return -1, err
 	}
 
-	spentVtxos := make([]clientTypes.Vtxo, 0, len(vtxos))
+	spentVtxos := make([]clienttypes.Vtxo, 0, len(vtxos))
 	txBody := func(querierWithTx *queries.Queries) error {
 		for _, vtxo := range vtxos {
 			if vtxo.Spent {
@@ -156,18 +156,18 @@ func (v *vtxoRepository) SpendVtxos(
 
 func (v *vtxoRepository) SweepVtxos(
 	ctx context.Context,
-	vtxosToSweep []clientTypes.Vtxo,
+	vtxosToSweep []clienttypes.Vtxo,
 ) (int, error) {
-	outpoints := make([]clientTypes.Outpoint, 0, len(vtxosToSweep))
+	outpoints := make([]clienttypes.Outpoint, 0, len(vtxosToSweep))
 	for _, vtxo := range vtxosToSweep {
 		outpoints = append(outpoints, vtxo.Outpoint)
 	}
-	vtxos, err := v.GetVtxos(ctx, outpoints)
+	vtxos, err := v.GetVtxosByOutpoints(ctx, outpoints)
 	if err != nil {
 		return -1, err
 	}
 
-	sweptVtxos := make([]clientTypes.Vtxo, 0)
+	sweptVtxos := make([]clienttypes.Vtxo, 0)
 	txBody := func(querierWithTx *queries.Queries) error {
 		for _, v := range vtxos {
 			if v.Swept {
@@ -203,18 +203,18 @@ func (v *vtxoRepository) SweepVtxos(
 
 func (v *vtxoRepository) UnrollVtxos(
 	ctx context.Context,
-	vtxosToUnroll []clientTypes.Vtxo,
+	vtxosToUnroll []clienttypes.Vtxo,
 ) (int, error) {
-	outpoints := make([]clientTypes.Outpoint, 0, len(vtxosToUnroll))
+	outpoints := make([]clienttypes.Outpoint, 0, len(vtxosToUnroll))
 	for _, vtxo := range vtxosToUnroll {
 		outpoints = append(outpoints, vtxo.Outpoint)
 	}
-	vtxos, err := v.GetVtxos(ctx, outpoints)
+	vtxos, err := v.GetVtxosByOutpoints(ctx, outpoints)
 	if err != nil {
 		return -1, err
 	}
 
-	unrolledVtxos := make([]clientTypes.Vtxo, 0)
+	unrolledVtxos := make([]clienttypes.Vtxo, 0)
 	txBody := func(querierWithTx *queries.Queries) error {
 		for _, v := range vtxos {
 			if v.Unrolled {
@@ -249,18 +249,18 @@ func (v *vtxoRepository) UnrollVtxos(
 }
 
 func (v *vtxoRepository) SettleVtxos(
-	ctx context.Context, spentVtxosMap map[clientTypes.Outpoint]string, settledBy string,
+	ctx context.Context, spentVtxosMap map[clienttypes.Outpoint]string, settledBy string,
 ) (int, error) {
-	outpoints := make([]clientTypes.Outpoint, 0, len(spentVtxosMap))
+	outpoints := make([]clienttypes.Outpoint, 0, len(spentVtxosMap))
 	for outpoint := range spentVtxosMap {
 		outpoints = append(outpoints, outpoint)
 	}
-	vtxos, err := v.GetVtxos(ctx, outpoints)
+	vtxos, err := v.GetVtxosByOutpoints(ctx, outpoints)
 	if err != nil {
 		return -1, err
 	}
 
-	settledVtxos := make([]clientTypes.Vtxo, 0, len(vtxos))
+	settledVtxos := make([]clienttypes.Vtxo, 0, len(vtxos))
 	txBody := func(querierWithTx *queries.Queries) error {
 		for _, vtxo := range vtxos {
 			if vtxo.Spent {
@@ -297,33 +297,10 @@ func (v *vtxoRepository) SettleVtxos(
 	return len(settledVtxos), nil
 }
 
-func (v *vtxoRepository) GetAllVtxos(
-	ctx context.Context,
-) (spendable, spent []clientTypes.Vtxo, err error) {
-	rows, err := v.querier.SelectAllVtxos(ctx)
-	if err != nil {
-		return
-	}
-	byOutpoint := make(map[string][]queries.AssetVtxoVw)
-	for _, row := range rows {
-		key := fmt.Sprintf("%s:%d", row.Txid, row.Vout)
-		byOutpoint[key] = append(byOutpoint[key], row)
-	}
-	for _, group := range byOutpoint {
-		vtxo := assetVtxoVwGroupToVtxo(group)
-		if vtxo.Spent || vtxo.Unrolled {
-			spent = append(spent, vtxo)
-		} else {
-			spendable = append(spendable, vtxo)
-		}
-	}
-	return
-}
-
-func (v *vtxoRepository) GetVtxos(
-	ctx context.Context, keys []clientTypes.Outpoint,
-) ([]clientTypes.Vtxo, error) {
-	vtxos := make([]clientTypes.Vtxo, 0, len(keys))
+func (v *vtxoRepository) GetVtxosByOutpoints(
+	ctx context.Context, keys []clienttypes.Outpoint,
+) ([]clienttypes.Vtxo, error) {
+	vtxos := make([]clienttypes.Vtxo, 0, len(keys))
 	for _, key := range keys {
 		rows, err := v.querier.SelectVtxo(ctx, queries.SelectVtxoParams{
 			Txid: key.Txid,
@@ -343,15 +320,75 @@ func (v *vtxoRepository) GetVtxos(
 	return vtxos, nil
 }
 
-func (v *vtxoRepository) GetSpendableVtxos(
+func (v *vtxoRepository) GetSpendableOrRecoverableVtxos(
 	ctx context.Context,
-) (spendable []clientTypes.Vtxo, err error) {
-	rows, err := v.querier.SelectSpendableVtxos(ctx)
+) (spendableOrRecoverable []clienttypes.Vtxo, err error) {
+	rows, err := v.querier.SelectSpendableOrRecoverableVtxos(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	return assetVtxoVwRowsToVtxos(rows), nil
+}
+
+func (v *vtxoRepository) GetVtxos(
+	ctx context.Context, q types.GetVtxoFilter,
+) ([]clienttypes.Vtxo, *types.Cursor, error) {
+	// We ask SQL for q.Limit+1 rows. If the database returns more than q.Limit rows,
+	// we know there's at least one more page, and the extra row's outpoint becomes the cursor
+	// for the next page. If it returns ≤ q.Limit, we've hit the end and Next stays nil.
+	params := queries.GetVtxosParams{
+		LimitPlusOne: int64(q.Limit) + 1,
+	}
+
+	// Translate the typed status filter into the string the SQL query expects.
+	// VtxoStatusAll leaves StatusFilter.Valid = false, which the WHERE clause
+	// interprets as "no status filter."
+	switch q.Status {
+	case types.VtxoStatusSpendable:
+		params.StatusFilter = sql.NullString{String: "spendable", Valid: true}
+	case types.VtxoStatusSpent:
+		params.StatusFilter = sql.NullString{String: "spent", Valid: true}
+	case types.VtxoStatusAll:
+		// No status filter at the SQL layer.
+	}
+
+	if q.AssetID != "" {
+		params.AssetID = sql.NullString{String: q.AssetID, Valid: true}
+	}
+
+	// Cursor position: SQL resumes from rows strictly less than
+	// (cursor_created_at, cursor_txid, cursor_vout) in the descending sort
+	// order. Nil After = first page; the cursor params stay invalid and the
+	// query's cursor predicate is a no-op.
+	if q.After != nil {
+		params.CursorCreatedAt = sql.NullInt64{Int64: q.After.CreatedAt, Valid: true}
+		params.CursorTxid = sql.NullString{String: q.After.Txid, Valid: true}
+		params.CursorVout = sql.NullInt64{Int64: int64(q.After.VOut), Valid: true}
+	}
+
+	rows, err := v.querier.GetVtxos(ctx, params)
+	if err != nil {
+		return nil, nil, err
+	}
+	vtxos := assetVtxoVwRowsToVtxos(rows)
+
+	// If we got back more than the caller asked for, the extra row is the
+	// "has more" sentinel: drop it and use its outpoint to build the cursor
+	// for the cursor page. Otherwise we hit the end of the dataset and Next
+	// stays nil, signaling no further pages.
+	var cursor *types.Cursor
+	if len(vtxos) > q.Limit {
+		vtxos = vtxos[:q.Limit]
+		last := vtxos[len(vtxos)-1]
+		cursor = &types.Cursor{
+			CreatedAt: last.CreatedAt.Unix(),
+			Txid:      last.Txid,
+			VOut:      last.VOut,
+		}
+	}
+
+	return vtxos, cursor, nil
 }
 
 func (v *vtxoRepository) GetEventChannel() <-chan types.VtxoEvent {
@@ -388,27 +425,31 @@ func (v *vtxoRepository) sendEvent(event types.VtxoEvent) {
 	log.Warn("failed to send vtxo event")
 }
 
-func assetVtxoVwRowsToVtxos(rows []queries.AssetVtxoVw) []clientTypes.Vtxo {
-	// group rows by (txid, vout)
+// assetVtxoVwRowsToVtxos folds the N×M (vtxo × asset) row stream produced by
+// asset_vtxo_vw into one Vtxo per outpoint. Preserves first-seen order of
+// outpoints, so SQL ORDER BY clauses are observable in the output.
+func assetVtxoVwRowsToVtxos(rows []queries.AssetVtxoVw) []clienttypes.Vtxo {
 	byOutpoint := make(map[string][]queries.AssetVtxoVw)
+	order := make([]string, 0)
 	for _, row := range rows {
 		key := fmt.Sprintf("%s:%d", row.Txid, row.Vout)
+		if _, ok := byOutpoint[key]; !ok {
+			order = append(order, key)
+		}
 		byOutpoint[key] = append(byOutpoint[key], row)
 	}
 
-	vtxos := make([]clientTypes.Vtxo, 0, len(byOutpoint))
-	for _, group := range byOutpoint {
-		vtxo := assetVtxoVwGroupToVtxo(group)
-		vtxos = append(vtxos, vtxo)
+	vtxos := make([]clienttypes.Vtxo, 0, len(order))
+	for _, key := range order {
+		vtxos = append(vtxos, assetVtxoVwGroupToVtxo(byOutpoint[key]))
 	}
-
 	return vtxos
 }
 
-// assetVtxoVwGroupToVtxo converts a group of AssetVtxoVw rows (same vtxo, one row per asset from the view) into one types.Vtxo.
-func assetVtxoVwGroupToVtxo(group []queries.AssetVtxoVw) clientTypes.Vtxo {
+// assetVtxoVwGroupToVtxo converts a group of AssetVtxoVw rows (same vtxo, one row per asset from the view) into one clienttypes.Vtxo.
+func assetVtxoVwGroupToVtxo(group []queries.AssetVtxoVw) clienttypes.Vtxo {
 	if len(group) == 0 {
-		return clientTypes.Vtxo{}
+		return clienttypes.Vtxo{}
 	}
 	row := group[0]
 	vtxoRow := queries.Vtxo{
@@ -442,7 +483,7 @@ func assetVtxoVwGroupToVtxo(group []queries.AssetVtxoVw) clientTypes.Vtxo {
 	return rowToVtxo(vtxoRow, assets)
 }
 
-func rowToVtxo(row queries.Vtxo, assetVtxos []queries.AssetVtxo) clientTypes.Vtxo {
+func rowToVtxo(row queries.Vtxo, assetVtxos []queries.AssetVtxo) clienttypes.Vtxo {
 	var expiresAt, createdAt time.Time
 	if row.ExpiresAt != 0 {
 		expiresAt = time.Unix(row.ExpiresAt, 0)
@@ -451,18 +492,18 @@ func rowToVtxo(row queries.Vtxo, assetVtxos []queries.AssetVtxo) clientTypes.Vtx
 		createdAt = time.Unix(row.CreatedAt, 0)
 	}
 
-	var assets []clientTypes.Asset
+	var assets []clienttypes.Asset
 	if len(assetVtxos) > 0 {
-		assets = make([]clientTypes.Asset, 0, len(assetVtxos))
+		assets = make([]clienttypes.Asset, 0, len(assetVtxos))
 		for _, av := range assetVtxos {
-			assets = append(assets, clientTypes.Asset{
+			assets = append(assets, clienttypes.Asset{
 				AssetId: av.AssetID,
 				Amount:  uint64(av.Amount),
 			})
 		}
 	}
-	return clientTypes.Vtxo{
-		Outpoint: clientTypes.Outpoint{
+	return clienttypes.Vtxo{
+		Outpoint: clienttypes.Outpoint{
 			Txid: row.Txid,
 			VOut: uint32(row.Vout),
 		},

--- a/store/sql/vtxo_store.go
+++ b/store/sql/vtxo_store.go
@@ -334,9 +334,13 @@ func (v *vtxoRepository) GetSpendableOrRecoverableVtxos(
 func (v *vtxoRepository) GetVtxos(
 	ctx context.Context, q types.GetVtxoFilter,
 ) ([]clienttypes.Vtxo, *types.Cursor, error) {
-	// We ask SQL for q.Limit+1 rows. If the database returns more than q.Limit rows,
-	// we know there's at least one more page, and the extra row's outpoint becomes the cursor
-	// for the next page. If it returns ≤ q.Limit, we've hit the end and Next stays nil.
+	if q.Limit <= 0 {
+		return nil, nil, fmt.Errorf("limit must be > 0, got %d", q.Limit)
+	}
+	// Ask SQL for q.Limit+1 VTXOs to detect whether another page exists.
+	// If more than q.Limit VTXOs are returned, trim the sentinel row and use
+	// the last returned VTXO as the next cursor anchor. The next query resumes
+	// strictly after that anchor in descending sort order.
 	params := queries.GetVtxosParams{
 		LimitPlusOne: int64(q.Limit) + 1,
 	}
@@ -373,22 +377,21 @@ func (v *vtxoRepository) GetVtxos(
 	}
 	vtxos := assetVtxoVwRowsToVtxos(rows)
 
-	// If we got back more than the caller asked for, the extra row is the
-	// "has more" sentinel: drop it and use its outpoint to build the cursor
-	// for the cursor page. Otherwise we hit the end of the dataset and Next
-	// stays nil, signaling no further pages.
-	var cursor *types.Cursor
+	// If we got back more than the caller asked for, the extra row is only a
+	// "has more" sentinel. Drop it and use the last returned VTXO as the next
+	// cursor anchor. Otherwise we hit the end and Next stays nil.
+	var next *types.Cursor
 	if len(vtxos) > q.Limit {
 		vtxos = vtxos[:q.Limit]
 		last := vtxos[len(vtxos)-1]
-		cursor = &types.Cursor{
+		next = &types.Cursor{
 			CreatedAt: last.CreatedAt.Unix(),
 			Txid:      last.Txid,
 			VOut:      last.VOut,
 		}
 	}
 
-	return vtxos, cursor, nil
+	return vtxos, next, nil
 }
 
 func (v *vtxoRepository) GetEventChannel() <-chan types.VtxoEvent {

--- a/store/vtxo_store_test.go
+++ b/store/vtxo_store_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -653,6 +654,63 @@ func TestVtxoStoreGetVtxos(t *testing.T) {
 					}
 				}
 				require.Fail(t, "multi-asset vtxo not found in WithAssetID result")
+			})
+
+			t.Run("tiebreaker on identical created_at", func(t *testing.T) {
+				// Seed N VTXOs with identical created_at and distinct
+				// (txid, vout). Page through in small pages and assert that
+				// every outpoint appears exactly once and the total count
+				// matches.
+				require.NoError(t, s.Clean(ctx))
+
+				const n = 10
+				sharedCreatedAt := time.Unix(base, 0)
+				tieVtxos := make([]clientTypes.Vtxo, n)
+				for i := range tieVtxos {
+					// Distinct txid per row; vout always 0. Lex-distinct txids
+					// give the (txid, vout) tiebreaker something to work with.
+					txid := fmt.Sprintf(
+						"%064x", i+1, // 64 hex chars = 32-byte txid
+					)
+					tieVtxos[i] = clientTypes.Vtxo{
+						Outpoint: clientTypes.Outpoint{Txid: txid, VOut: 0},
+						Script:   testVtxos[0].Script,
+						Amount:   uint64(1000 + i),
+						CommitmentTxids: []string{
+							"0000000000000000000000000000000000000000000000000000000000000000",
+						},
+						CreatedAt: sharedCreatedAt,
+						ExpiresAt: testVtxos[0].ExpiresAt,
+					}
+				}
+				seedVtxos(t, s, tieVtxos...)
+
+				seen := make(map[clientTypes.Outpoint]int, n)
+				var cursor *types.Cursor
+				pages := 0
+				for {
+					pages++
+					require.Less(t, pages, n+2, "pagination did not terminate")
+
+					vtxos, next, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+						Status: types.VtxoStatusAll,
+						Limit:  3, // small page so we exercise multiple cursor hops
+						After:  cursor,
+					})
+					require.NoError(t, err)
+					for _, v := range vtxos {
+						seen[v.Outpoint]++
+					}
+					if next == nil {
+						break
+					}
+					cursor = next
+				}
+
+				require.Len(t, seen, n, "expected exactly %d distinct outpoints", n)
+				for op, count := range seen {
+					require.Equal(t, 1, count, "outpoint %v seen %d times (want 1)", op, count)
+				}
 			})
 		})
 	})

--- a/store/vtxo_store_test.go
+++ b/store/vtxo_store_test.go
@@ -1,0 +1,770 @@
+package store_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
+	clientTypes "github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/arkade-os/go-sdk/store"
+	"github.com/arkade-os/go-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures (moved verbatim from service_test.go)
+// ---------------------------------------------------------------------------
+
+var (
+	testVtxoAsset1 = clientTypes.Asset{
+		AssetId: asset.AssetId{
+			Txid: [32]byte{
+				0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x0a,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00,
+			},
+			Index: 12,
+		}.String(),
+		Amount: 123456789,
+	}
+
+	testVtxoAsset2 = clientTypes.Asset{
+		AssetId: asset.AssetId{
+			Txid: [32]byte{
+				0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x0a,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00,
+			},
+			Index: 0,
+		}.String(),
+		Amount: 987654321,
+	}
+
+	testVtxos = []clientTypes.Vtxo{
+		{
+			Outpoint: clientTypes.Outpoint{
+				Txid: "0000000000000000000000000000000000000000000000000000000000000000",
+				VOut: 0,
+			},
+			Script: "0000000000000000000000000000000000000000000000000000000000000001",
+			Amount: 1000,
+			CommitmentTxids: []string{
+				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+			ExpiresAt:    time.Unix(1748143068, 0),
+			CreatedAt:    time.Unix(1746143068, 0),
+			Preconfirmed: true,
+		},
+		{
+			Outpoint: clientTypes.Outpoint{
+				Txid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				VOut: 0,
+			},
+			Script: "0000000000000000000000000000000000000000000000000000000000000001",
+			Amount: 2000,
+			CommitmentTxids: []string{
+				"0000000000000000000000000000000000000000000000000000000000000000",
+			},
+			ExpiresAt: time.Unix(1748143068, 0),
+			CreatedAt: time.Unix(1746143068, 0),
+		},
+		{
+			Outpoint: clientTypes.Outpoint{
+				Txid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				VOut: 0,
+			},
+			Script: "0000000000000000000000000000000000000000000000000000000000000001",
+			Amount: 3000,
+			CommitmentTxids: []string{
+				"0000000000000000000000000000000000000000000000000000000000000000",
+			},
+			ExpiresAt: time.Unix(1748143068, 0),
+			CreatedAt: time.Unix(1746143068, 0),
+			// vtxo with multiple assets
+			Assets: []clientTypes.Asset{testVtxoAsset1, testVtxoAsset2},
+		},
+		{
+			Outpoint: clientTypes.Outpoint{
+				Txid: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+				VOut: 0,
+			},
+			Script: "0000000000000000000000000000000000000000000000000000000000000001",
+			Amount: 3000,
+			CommitmentTxids: []string{
+				"0000000000000000000000000000000000000000000000000000000000000000",
+			},
+			ExpiresAt: time.Unix(1748143068, 0),
+			CreatedAt: time.Unix(1746143068, 0),
+			// vtxo with single asset
+			Assets: []clientTypes.Asset{testVtxoAsset1},
+		},
+	}
+
+	testVtxoKeys = []clientTypes.Outpoint{
+		{
+			Txid: "0000000000000000000000000000000000000000000000000000000000000000",
+			VOut: 0,
+		},
+		{
+			Txid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			VOut: 0,
+		},
+		{
+			Txid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			VOut: 0,
+		},
+		{
+			Txid: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			VOut: 0,
+		},
+	}
+
+	testSpendVtxoKeys = map[clientTypes.Outpoint]string{
+		testVtxoKeys[0]: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+
+	testSettleVtxoKeys = map[clientTypes.Outpoint]string{
+		testVtxoKeys[1]: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	}
+
+	arkTxid = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func forEachVtxoBackend(t *testing.T, fn func(t *testing.T, s types.VtxoStore)) {
+	t.Helper()
+
+	backends := []struct {
+		name   string
+		config store.Config
+	}{
+		{name: "sql", config: store.Config{StoreType: types.SQLStore, Args: t.TempDir()}},
+	}
+
+	for _, b := range backends {
+		t.Run(b.name, func(t *testing.T) {
+			svc, err := store.NewStore(b.config)
+			require.NoError(t, err)
+			t.Cleanup(svc.Close)
+
+			vs := svc.VtxoStore()
+			require.NotNil(t, vs)
+			fn(t, vs)
+		})
+	}
+}
+
+func seedVtxos(t *testing.T, s types.VtxoStore, vtxos ...clientTypes.Vtxo) {
+	t.Helper()
+	if len(vtxos) == 0 {
+		return
+	}
+	n, err := s.AddVtxos(t.Context(), vtxos)
+	require.NoError(t, err)
+	require.Equal(t, len(vtxos), n)
+}
+
+func requireVtxosListEqual(t *testing.T, expected, actual []clientTypes.Vtxo) {
+	t.Helper()
+	require.Len(t, expected, len(actual))
+	for _, v := range expected {
+		found := false
+		for _, a := range actual {
+			if v.Outpoint == a.Outpoint {
+				require.Equal(t, v, a)
+				found = true
+				break
+			}
+		}
+		require.True(t, found)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests — one per VtxoStore interface method
+// ---------------------------------------------------------------------------
+
+func TestVtxoStoreAddVtxos(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+
+			t.Run("insert N vtxos", func(t *testing.T) {
+				n, err := s.AddVtxos(ctx, testVtxos)
+				require.NoError(t, err)
+				require.Equal(t, len(testVtxos), n)
+			})
+
+			t.Run("idempotent reinsert returns 0", func(t *testing.T) {
+				n, err := s.AddVtxos(ctx, testVtxos)
+				require.NoError(t, err)
+				require.Zero(t, n)
+			})
+
+			t.Run("multi-asset vtxo round-trips correctly", func(t *testing.T) {
+				got, err := s.GetVtxosByOutpoints(ctx, testVtxoKeys)
+				require.NoError(t, err)
+				requireVtxosListEqual(t, testVtxos, got)
+			})
+		})
+	})
+}
+
+func TestVtxoStoreSpendVtxos(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+			seedVtxos(t, s, testVtxos...)
+
+			t.Run("spends one outpoint", func(t *testing.T) {
+				n, err := s.SpendVtxos(ctx, testSpendVtxoKeys, arkTxid)
+				require.NoError(t, err)
+				require.Equal(t, len(testSpendVtxoKeys), n)
+			})
+
+			t.Run("second call for same outpoints returns 0", func(t *testing.T) {
+				n, err := s.SpendVtxos(ctx, testSpendVtxoKeys, arkTxid)
+				require.NoError(t, err)
+				require.Zero(t, n)
+			})
+
+			t.Run("spent vtxo has correct fields", func(t *testing.T) {
+				vtxos, _, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status: types.VtxoStatusSpent,
+					Limit:  1000,
+				})
+				require.NoError(t, err)
+				require.Len(t, vtxos, 1)
+				v := vtxos[0]
+				require.True(t, v.Spent)
+				require.Equal(t, testSpendVtxoKeys[v.Outpoint], v.SpentBy)
+				require.Equal(t, arkTxid, v.ArkTxid)
+			})
+		})
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+
+			t.Run("empty map returns 0, no error", func(t *testing.T) {
+				n, err := s.SpendVtxos(ctx, map[clientTypes.Outpoint]string{}, "any")
+				require.NoError(t, err)
+				require.Zero(t, n)
+			})
+
+			t.Run("unknown outpoints returns 0, no error", func(t *testing.T) {
+				unknown := map[clientTypes.Outpoint]string{
+					{Txid: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", VOut: 0}: "tx1",
+				}
+				n, err := s.SpendVtxos(ctx, unknown, "any")
+				require.NoError(t, err)
+				require.Zero(t, n)
+			})
+		})
+	})
+}
+
+func TestVtxoStoreSettleVtxos(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+			seedVtxos(t, s, testVtxos...)
+
+			t.Run("mark settle populates SpentBy and SettledBy", func(t *testing.T) {
+				n, err := s.SettleVtxos(ctx, testSettleVtxoKeys, settledBy)
+				require.NoError(t, err)
+				require.Equal(t, len(testSettleVtxoKeys), n)
+
+				vtxos, _, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status: types.VtxoStatusSpent,
+					Limit:  1000,
+				})
+				require.NoError(t, err)
+				for _, v := range vtxos {
+					expectedSpentBy, ok := testSettleVtxoKeys[v.Outpoint]
+					if ok {
+						require.Equal(t, expectedSpentBy, v.SpentBy)
+						require.Equal(t, settledBy, v.SettledBy)
+					}
+				}
+			})
+
+			t.Run("second call for same outpoints returns 0", func(t *testing.T) {
+				n, err := s.SettleVtxos(ctx, testSettleVtxoKeys, settledBy)
+				require.NoError(t, err)
+				require.Zero(t, n)
+			})
+		})
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+
+			t.Run("empty map returns 0, no error", func(t *testing.T) {
+				n, err := s.SettleVtxos(ctx, map[clientTypes.Outpoint]string{}, "any")
+				require.NoError(t, err)
+				require.Zero(t, n)
+			})
+
+			t.Run("unknown outpoints returns 0, no error", func(t *testing.T) {
+				unknown := map[clientTypes.Outpoint]string{
+					{Txid: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", VOut: 0}: "tx1",
+				}
+				n, err := s.SettleVtxos(ctx, unknown, "any")
+				require.NoError(t, err)
+				require.Zero(t, n)
+			})
+		})
+	})
+}
+
+func TestVtxoStoreSweepVtxos(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+			seedVtxos(t, s, testVtxos...)
+
+			toSweep := testVtxos[:2]
+
+			t.Run("mark swept sets Swept=true", func(t *testing.T) {
+				n, err := s.SweepVtxos(ctx, toSweep)
+				require.NoError(t, err)
+				require.Equal(t, len(toSweep), n)
+
+				got, err := s.GetVtxosByOutpoints(ctx, []clientTypes.Outpoint{
+					toSweep[0].Outpoint,
+					toSweep[1].Outpoint,
+				})
+				require.NoError(t, err)
+				for _, v := range got {
+					require.True(t, v.Swept)
+				}
+			})
+
+			t.Run("idempotent re-sweep returns 0", func(t *testing.T) {
+				n, err := s.SweepVtxos(ctx, toSweep)
+				require.NoError(t, err)
+				require.Zero(t, n)
+			})
+		})
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+
+			t.Run("empty input returns 0, no error", func(t *testing.T) {
+				n, err := s.SweepVtxos(ctx, nil)
+				require.NoError(t, err)
+				require.Zero(t, n)
+			})
+		})
+	})
+}
+
+func TestVtxoStoreUnrollVtxos(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+			seedVtxos(t, s, testVtxos...)
+
+			toUnroll := testVtxos[:2]
+
+			t.Run("mark unrolled sets Unrolled=true", func(t *testing.T) {
+				n, err := s.UnrollVtxos(ctx, toUnroll)
+				require.NoError(t, err)
+				require.Equal(t, len(toUnroll), n)
+
+				got, err := s.GetVtxosByOutpoints(ctx, []clientTypes.Outpoint{
+					toUnroll[0].Outpoint,
+					toUnroll[1].Outpoint,
+				})
+				require.NoError(t, err)
+				for _, v := range got {
+					require.True(t, v.Unrolled)
+				}
+			})
+
+			t.Run("idempotent re-unroll returns 0", func(t *testing.T) {
+				n, err := s.UnrollVtxos(ctx, toUnroll)
+				require.NoError(t, err)
+				require.Zero(t, n)
+			})
+		})
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+
+			t.Run("empty input returns 0, no error", func(t *testing.T) {
+				n, err := s.UnrollVtxos(ctx, nil)
+				require.NoError(t, err)
+				require.Zero(t, n)
+			})
+		})
+	})
+}
+
+func TestVtxoStoreGetSpendableOrRecoverableVtxos(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+			seedVtxos(t, s, testVtxos...)
+
+			t.Run("returns all non-spent non-unrolled vtxos initially", func(t *testing.T) {
+				got, err := s.GetSpendableOrRecoverableVtxos(ctx)
+				require.NoError(t, err)
+				require.Len(t, got, len(testVtxos))
+				for _, v := range got {
+					require.False(t, v.Spent)
+					require.False(t, v.Unrolled)
+				}
+			})
+
+			t.Run("spent vtxos are excluded", func(t *testing.T) {
+				_, err := s.SpendVtxos(ctx, testSpendVtxoKeys, arkTxid)
+				require.NoError(t, err)
+
+				got, err := s.GetSpendableOrRecoverableVtxos(ctx)
+				require.NoError(t, err)
+				require.Len(t, got, len(testVtxos)-len(testSpendVtxoKeys))
+				for _, v := range got {
+					require.False(t, v.Spent)
+				}
+			})
+
+			t.Run("unrolled vtxos are excluded", func(t *testing.T) {
+				toUnroll := []clientTypes.Vtxo{testVtxos[1]}
+				_, err := s.UnrollVtxos(ctx, toUnroll)
+				require.NoError(t, err)
+
+				got, err := s.GetSpendableOrRecoverableVtxos(ctx)
+				require.NoError(t, err)
+				// testVtxos[0] spent, testVtxos[1] unrolled → 2 remaining
+				require.Len(t, got, len(testVtxos)-len(testSpendVtxoKeys)-1)
+				for _, v := range got {
+					require.False(t, v.Spent)
+					require.False(t, v.Unrolled)
+				}
+			})
+		})
+	})
+}
+
+func TestVtxoStoreGetVtxosByOutpoints(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+			seedVtxos(t, s, testVtxos...)
+
+			t.Run("returns vtxos for matching outpoints", func(t *testing.T) {
+				got, err := s.GetVtxosByOutpoints(ctx, testVtxoKeys)
+				require.NoError(t, err)
+				requireVtxosListEqual(t, testVtxos, got)
+			})
+
+			t.Run("preserves multi-asset hydration", func(t *testing.T) {
+				got, err := s.GetVtxosByOutpoints(ctx, []clientTypes.Outpoint{testVtxoKeys[2]})
+				require.NoError(t, err)
+				require.Len(t, got, 1)
+				require.Equal(t, testVtxos[2].Assets, got[0].Assets)
+			})
+		})
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+
+			t.Run("unknown outpoint returns empty slice, no error", func(t *testing.T) {
+				got, err := s.GetVtxosByOutpoints(ctx, []clientTypes.Outpoint{
+					{
+						Txid: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+						VOut: 0,
+					},
+				})
+				require.NoError(t, err)
+				require.Empty(t, got)
+			})
+
+			t.Run("empty input returns empty slice, no error", func(t *testing.T) {
+				got, err := s.GetVtxosByOutpoints(ctx, nil)
+				require.NoError(t, err)
+				require.Empty(t, got)
+			})
+		})
+	})
+}
+
+func TestVtxoStoreGetVtxos(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+
+			// Seed a deterministic dataset: assign sequential created_at values so
+			// descending sort is fully ordered (no ties).
+			seed := make([]clientTypes.Vtxo, len(testVtxos))
+			copy(seed, testVtxos)
+			base := time.Now().Add(-time.Hour).Unix()
+			for i := range seed {
+				seed[i].CreatedAt = time.Unix(base+int64(i), 0)
+			}
+			seedVtxos(t, s, seed...)
+
+			t.Run("first page returns newest first", func(t *testing.T) {
+				vtxos, cursor, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status: types.VtxoStatusAll,
+					Limit:  2,
+				})
+				require.NoError(t, err)
+				require.Len(t, vtxos, 2)
+				require.NotNil(t, cursor)
+				// Descending by created_at — first element is the newest.
+				require.False(t, vtxos[0].CreatedAt.Before(vtxos[1].CreatedAt))
+			})
+
+			t.Run("cursor resumes correctly", func(t *testing.T) {
+				vtxos, cursor, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status: types.VtxoStatusAll,
+					Limit:  2,
+				})
+				require.NoError(t, err)
+				require.NotNil(t, cursor)
+
+				vtxos2, cursor2, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status: types.VtxoStatusAll,
+					Limit:  2,
+					After:  cursor,
+				})
+				require.NoError(t, err)
+				require.NotEmpty(t, vtxos2)
+				require.Nil(t, cursor2)
+
+				// No overlap between page 1 and page 2.
+				seen := map[clientTypes.Outpoint]bool{}
+				for _, v := range vtxos {
+					seen[v.Outpoint] = true
+				}
+				for _, v := range vtxos2 {
+					require.False(t, seen[v.Outpoint])
+				}
+			})
+
+			t.Run("limit larger than dataset returns nil Next", func(t *testing.T) {
+				vtxos, cursor, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status: types.VtxoStatusAll,
+					Limit:  1000,
+				})
+				require.NoError(t, err)
+				require.Len(t, vtxos, len(seed))
+				require.Nil(t, cursor)
+			})
+
+			t.Run("limit may change between pages", func(t *testing.T) {
+				vtxos, cursor, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status: types.VtxoStatusAll,
+					Limit:  1,
+				})
+				require.NoError(t, err)
+				require.Len(t, vtxos, 1)
+				require.NotNil(t, cursor)
+
+				vtxos2, cursor2, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status: types.VtxoStatusAll,
+					Limit:  1000,
+					After:  cursor,
+				})
+				require.NoError(t, err)
+				require.Len(t, vtxos2, len(seed)-1)
+				require.Nil(t, cursor2)
+			})
+
+			t.Run("status filter spendable", func(t *testing.T) {
+				// Spend two of the seeded VTXOs.
+				require.NoError(t, s.Clean(ctx))
+				seedVtxos(t, s, seed...)
+				spendMap := map[clientTypes.Outpoint]string{
+					seed[0].Outpoint: "spentby0",
+					seed[1].Outpoint: "spentby1",
+				}
+				_, err := s.SpendVtxos(ctx, spendMap, "arktx-test")
+				require.NoError(t, err)
+
+				vtxos, _, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status: types.VtxoStatusSpendable,
+					Limit:  1000,
+				})
+				require.NoError(t, err)
+				for _, v := range vtxos {
+					require.False(t, v.Spent)
+					require.False(t, v.Unrolled)
+				}
+				require.Len(t, vtxos, len(seed)-2)
+			})
+
+			t.Run("status filter spent", func(t *testing.T) {
+				vtxos, _, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status: types.VtxoStatusSpent,
+					Limit:  1000,
+				})
+				require.NoError(t, err)
+				require.Len(t, vtxos, 2)
+				for _, v := range vtxos {
+					require.True(t, v.Spent || v.Unrolled)
+				}
+			})
+
+			t.Run("empty result has nil Next and empty slice", func(t *testing.T) {
+				require.NoError(t, s.Clean(ctx))
+				vtxos, cursor, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status: types.VtxoStatusAll,
+					Limit:  10,
+				})
+				require.NoError(t, err)
+				require.Empty(t, vtxos)
+				require.Nil(t, cursor)
+			})
+
+			t.Run("WithAssetID filter semantics", func(t *testing.T) {
+				require.NoError(t, s.Clean(ctx))
+				// seed[2] has both assets; seed[3] has only asset1.
+				seedVtxos(t, s, seed[2], seed[3])
+
+				// Querying with asset1 should return both vtxos.
+				vtxos, _, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status:  types.VtxoStatusAll,
+					AssetID: testVtxoAsset1.AssetId,
+					Limit:   1000,
+				})
+				require.NoError(t, err)
+				require.Len(t, vtxos, 2)
+
+				// The multi-asset vtxo (seed[2]) still carries both assets.
+				for _, v := range vtxos {
+					if v.Outpoint == seed[2].Outpoint {
+						require.Equal(t, seed[2].Assets, v.Assets)
+						return
+					}
+				}
+				require.Fail(t, "multi-asset vtxo not found in WithAssetID result")
+			})
+		})
+	})
+}
+
+func TestVtxoStoreClean(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+
+			t.Run("empty store", func(t *testing.T) {
+				require.NoError(t, s.Clean(ctx))
+			})
+
+			t.Run("non-empty store data is removed", func(t *testing.T) {
+				seedVtxos(t, s, testVtxos...)
+
+				got, err := s.GetSpendableOrRecoverableVtxos(ctx)
+				require.NoError(t, err)
+				require.NotEmpty(t, got)
+
+				require.NoError(t, s.Clean(ctx))
+
+				got, err = s.GetSpendableOrRecoverableVtxos(ctx)
+				require.NoError(t, err)
+				require.Empty(t, got)
+			})
+
+			t.Run("clean is idempotent", func(t *testing.T) {
+				require.NoError(t, s.Clean(ctx))
+				got, err := s.GetSpendableOrRecoverableVtxos(ctx)
+				require.NoError(t, err)
+				require.Empty(t, got)
+			})
+
+			t.Run("reseed after clean works correctly", func(t *testing.T) {
+				seedVtxos(t, s, testVtxos...)
+				require.NoError(t, s.Clean(ctx))
+
+				// Re-seeding the same vtxos must not collide with leftover state.
+				seedVtxos(t, s, testVtxos...)
+				got, err := s.GetSpendableOrRecoverableVtxos(ctx)
+				require.NoError(t, err)
+				require.Len(t, got, len(testVtxos))
+			})
+		})
+	})
+}
+
+func TestVtxoStoreGetEventChannel(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		forEachVtxoBackend(t, func(t *testing.T, s types.VtxoStore) {
+			ctx := t.Context()
+			timeout := time.Second
+
+			ch := s.GetEventChannel()
+			require.NotNil(t, ch)
+
+			drainEvent := func(t *testing.T, wantType types.VtxoEventType) types.VtxoEvent {
+				t.Helper()
+				select {
+				case ev := <-ch:
+					require.Equal(t, wantType, ev.Type)
+					return ev
+				case <-time.After(timeout):
+					t.Fatalf("timed out waiting for event %s", wantType)
+					return types.VtxoEvent{}
+				}
+			}
+
+			t.Run("AddVtxos emits VtxosAdded", func(t *testing.T) {
+				n, err := s.AddVtxos(ctx, testVtxos)
+				require.NoError(t, err)
+				require.Equal(t, len(testVtxos), n)
+
+				ev := drainEvent(t, types.VtxosAdded)
+				require.Len(t, ev.Vtxos, len(testVtxos))
+			})
+
+			t.Run("SpendVtxos emits VtxosSpent", func(t *testing.T) {
+				_, err := s.SpendVtxos(ctx, testSpendVtxoKeys, arkTxid)
+				require.NoError(t, err)
+
+				ev := drainEvent(t, types.VtxosSpent)
+				require.Len(t, ev.Vtxos, len(testSpendVtxoKeys))
+			})
+
+			t.Run("SettleVtxos emits VtxoSettled", func(t *testing.T) {
+				_, err := s.SettleVtxos(ctx, testSettleVtxoKeys, settledBy)
+				require.NoError(t, err)
+
+				ev := drainEvent(t, types.VtxoSettled)
+				require.Len(t, ev.Vtxos, len(testSettleVtxoKeys))
+			})
+
+			t.Run("SweepVtxos emits VtxosSwept", func(t *testing.T) {
+				toSweep := []clientTypes.Vtxo{testVtxos[2]}
+				_, err := s.SweepVtxos(ctx, toSweep)
+				require.NoError(t, err)
+
+				ev := drainEvent(t, types.VtxosSwept)
+				require.Len(t, ev.Vtxos, 1)
+			})
+
+			t.Run("UnrollVtxos emits VtxosUnrolled", func(t *testing.T) {
+				toUnroll := []clientTypes.Vtxo{testVtxos[3]}
+				_, err := s.UnrollVtxos(ctx, toUnroll)
+				require.NoError(t, err)
+
+				ev := drainEvent(t, types.VtxosUnrolled)
+				require.Len(t, ev.Vtxos, 1)
+			})
+		})
+	})
+}

--- a/test/docker/server.Dockerfile
+++ b/test/docker/server.Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/test/docker/wallet.Dockerfile
+++ b/test/docker/wallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet-daemon binary
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 ARG VERSION
 ARG TARGETOS

--- a/test/e2e/asset_test.go
+++ b/test/e2e/asset_test.go
@@ -398,11 +398,11 @@ func TestAssetBurn(t *testing.T) {
 }
 
 func listVtxosWithAsset(t *testing.T, client sdk.Wallet, assetID string) []clientTypes.Vtxo {
-	vtxos, _, err := client.ListVtxos(t.Context())
+	vtxos, _, err := client.ListVtxos(t.Context(), sdk.WithSpendableOnly())
 	require.NoError(t, err)
+	require.NotEmpty(t, vtxos)
 
 	assetVtxos := make([]clientTypes.Vtxo, 0, len(vtxos))
-
 	for _, vtxo := range vtxos {
 		for _, asset := range vtxo.Assets {
 			if asset.AssetId == assetID {

--- a/test/e2e/exit_test.go
+++ b/test/e2e/exit_test.go
@@ -192,7 +192,7 @@ func TestUnilateralExit(t *testing.T) {
 			break
 		}
 
-		_, spent, err := alice.ListVtxos(ctx)
+		spent, _, err := alice.ListVtxos(ctx, arksdk.WithSpentOnly())
 		require.NoError(t, err)
 		require.NotEmpty(t, spent)
 		require.Len(t, spent, 1)
@@ -282,7 +282,7 @@ func TestUnilateralExit(t *testing.T) {
 			break
 		}
 
-		_, spent, err := bob.ListVtxos(ctx)
+		spent, _, err := bob.ListVtxos(ctx, arksdk.WithSpentOnly())
 		require.NoError(t, err)
 		require.NotEmpty(t, spent)
 		require.Len(t, spent, 1)

--- a/test/e2e/hd_wallet_test.go
+++ b/test/e2e/hd_wallet_test.go
@@ -472,7 +472,8 @@ func waitForSpendableVtxos(
 
 	var spendable []clientTypes.Vtxo
 	require.Eventually(t, func() bool {
-		spendable, _, err := client.ListVtxos(t.Context(), sdk.WithSpendableOnly())
+		var err error
+		spendable, _, err = client.ListVtxos(t.Context(), sdk.WithSpendableOnly())
 		if err != nil {
 			return false
 		}

--- a/test/e2e/hd_wallet_test.go
+++ b/test/e2e/hd_wallet_test.go
@@ -100,7 +100,9 @@ func TestHDWalletRecoversFundsAtRestore(t *testing.T) {
 	// Scenario 3: Alice restores from seed and discovers all used keys on startup.
 	aliceClientHD = setupClient(t, seed, sdk.WithGapLimit(50))
 
-	restoredSpendable, restoredSpent, err := aliceClientHD.ListVtxos(ctx)
+	restoredSpendable, _, err := aliceClientHD.ListVtxos(ctx, sdk.WithSpendableOnly())
+	require.NoError(t, err)
+	restoredSpent, _, err := aliceClientHD.ListVtxos(ctx, sdk.WithSpentOnly())
 	require.NoError(t, err)
 	require.Len(t, restoredSpent, 0)
 	require.Len(t, restoredSpendable, 2)
@@ -177,7 +179,9 @@ func TestHDWalletDoesNotRecoverVtxoBeyondConfiguredGapLimit(t *testing.T) {
 
 	aliceClientHD = setupClient(t, seed, sdk.WithGapLimit(gapLimit))
 
-	restoredSpendable, restoredSpent, err := aliceClientHD.ListVtxos(ctx)
+	restoredSpendable, _, err := aliceClientHD.ListVtxos(ctx, sdk.WithSpendableOnly())
+	require.NoError(t, err)
+	restoredSpent, _, err := aliceClientHD.ListVtxos(ctx, sdk.WithSpentOnly())
 	require.NoError(t, err)
 	require.Len(t, restoredSpent, 0)
 	require.Len(t, restoredSpendable, 1)
@@ -240,7 +244,11 @@ func TestHDWalletRestoresMixedOnchainAndOffchainState(t *testing.T) {
 
 	const wantOffchainTotal = uint64(50_000)
 	require.Eventually(t, func() bool {
-		spendable, spent, err := aliceClientHD.ListVtxos(ctx)
+		spendable, _, err := aliceClientHD.ListVtxos(ctx, sdk.WithSpendableOnly())
+		if err != nil {
+			return false
+		}
+		spent, _, err := aliceClientHD.ListVtxos(ctx, sdk.WithSpentOnly())
 		if err != nil {
 			return false
 		}
@@ -464,8 +472,7 @@ func waitForSpendableVtxos(
 
 	var spendable []clientTypes.Vtxo
 	require.Eventually(t, func() bool {
-		var err error
-		spendable, _, err = client.ListVtxos(t.Context())
+		spendable, _, err := client.ListVtxos(t.Context(), sdk.WithSpendableOnly())
 		if err != nil {
 			return false
 		}

--- a/test/e2e/restore_smoke_test.go
+++ b/test/e2e/restore_smoke_test.go
@@ -47,8 +47,9 @@ func TestSmokeWalletRestore(t *testing.T) {
 		len(offchainAddresses), totalAddresses,
 	)
 
-	vtxos, _, err := alice.ListVtxos(ctx)
+	page, err := alice.ListVtxos(ctx, arksdk.WithSpendableOnly())
 	require.NoError(t, err, "❌ funding failed: expected no error on getting vtxos, got %w", err)
+	vtxos := page.Vtxos
 	require.Len(
 		t, vtxos, expectedVtxos,
 		"❌ funding failed: got %d vtxos, expected %d", len(vtxos), expectedVtxos,
@@ -91,8 +92,9 @@ func TestSmokeWalletRestore(t *testing.T) {
 		len(offchainAddressesRestored), totalAddresses,
 	)
 
-	vtxosRestored, _, err := aliceRestored.ListVtxos(ctx)
+	pageRestored, err := aliceRestored.ListVtxos(ctx, arksdk.WithSpendableOnly())
 	require.NoError(t, err, "❌ restore failed: expected no error, got %w", err)
+	vtxosRestored := pageRestored.Vtxos
 	require.Len(
 		t, vtxosRestored, len(vtxos),
 		"❌ restore failed: got %d restored vtxos, expected %d",

--- a/test/e2e/restore_smoke_test.go
+++ b/test/e2e/restore_smoke_test.go
@@ -47,9 +47,8 @@ func TestSmokeWalletRestore(t *testing.T) {
 		len(offchainAddresses), totalAddresses,
 	)
 
-	page, err := alice.ListVtxos(ctx, arksdk.WithSpendableOnly())
+	vtxos, _, err := alice.ListVtxos(ctx, arksdk.WithSpendableOnly())
 	require.NoError(t, err, "❌ funding failed: expected no error on getting vtxos, got %w", err)
-	vtxos := page.Vtxos
 	require.Len(
 		t, vtxos, expectedVtxos,
 		"❌ funding failed: got %d vtxos, expected %d", len(vtxos), expectedVtxos,
@@ -92,9 +91,8 @@ func TestSmokeWalletRestore(t *testing.T) {
 		len(offchainAddressesRestored), totalAddresses,
 	)
 
-	pageRestored, err := aliceRestored.ListVtxos(ctx, arksdk.WithSpendableOnly())
+	vtxosRestored, _, err := aliceRestored.ListVtxos(ctx, arksdk.WithSpendableOnly())
 	require.NoError(t, err, "❌ restore failed: expected no error, got %w", err)
-	vtxosRestored := pageRestored.Vtxos
 	require.Len(
 		t, vtxosRestored, len(vtxos),
 		"❌ restore failed: got %d restored vtxos, expected %d",

--- a/test/e2e/transaction_test.go
+++ b/test/e2e/transaction_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/offchain"
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
 	clientTypes "github.com/arkade-os/arkd/pkg/client-lib/types"
+	arksdk "github.com/arkade-os/go-sdk"
 	"github.com/arkade-os/go-sdk/contract"
 	types "github.com/arkade-os/go-sdk/types"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -50,7 +51,7 @@ func TestOffchainTx(t *testing.T) {
 		require.Equal(t, 1000, int(bobVtxo1.Amount))
 		require.Equal(t, txid, bobVtxo1.Txid)
 
-		bobVtxos, _, err := bob.ListVtxos(ctx)
+		bobVtxos, _, err := bob.ListVtxos(ctx, arksdk.WithSpendableOnly())
 		require.NoError(t, err)
 		require.Len(t, bobVtxos, 1)
 
@@ -69,7 +70,7 @@ func TestOffchainTx(t *testing.T) {
 		require.Equal(t, 10000, int(bobVtxo2.Amount))
 		require.Equal(t, txid, bobVtxo2.Txid)
 
-		bobVtxos, _, err = bob.ListVtxos(ctx)
+		bobVtxos, _, err = bob.ListVtxos(ctx, arksdk.WithSpendableOnly())
 		require.NoError(t, err)
 		require.Len(t, bobVtxos, 2)
 
@@ -88,7 +89,7 @@ func TestOffchainTx(t *testing.T) {
 		require.Equal(t, 10000, int(bobVtxo3.Amount))
 		require.Equal(t, txid, bobVtxo3.Txid)
 
-		bobVtxos, _, err = bob.ListVtxos(ctx)
+		bobVtxos, _, err = bob.ListVtxos(ctx, arksdk.WithSpendableOnly())
 		require.NoError(t, err)
 		require.Len(t, bobVtxos, 3)
 
@@ -107,7 +108,7 @@ func TestOffchainTx(t *testing.T) {
 		require.Equal(t, 10000, int(bobVtxo4.Amount))
 		require.Equal(t, txid, bobVtxo4.Txid)
 
-		bobVtxos, _, err = bob.ListVtxos(ctx)
+		bobVtxos, _, err = bob.ListVtxos(ctx, arksdk.WithSpendableOnly())
 		require.NoError(t, err)
 		require.Len(t, bobVtxos, 4)
 

--- a/test/e2e/vtxo_pagination_test.go
+++ b/test/e2e/vtxo_pagination_test.go
@@ -42,8 +42,8 @@ func TestE2EVtxoPagination(t *testing.T) {
 		require.Equal(t, 4, pages)
 		require.Equal(t, 10, len(walked))
 		requireNoDuplicateOutpoints(t, walked)
-		require.GreaterOrEqual(t, pages*limit, len(reference), "pages*limit must cover reference count")
-		require.LessOrEqual(t, pages*limit, len(reference)+limit, "only the final page may be partial")
+		require.GreaterOrEqual(t, pages*limit, len(reference))
+		require.LessOrEqual(t, pages*limit, len(reference)+limit)
 	})
 
 	t.Run("end-of-pagination returns nil cursor", func(t *testing.T) {
@@ -97,7 +97,12 @@ func TestE2EVtxoPagination(t *testing.T) {
 		require.NoError(t, err)
 		require.LessOrEqual(t, len(page2), 7, "second page must respect changed limit")
 		requireNoOutpointOverlap(t, page1, page2)
-		require.Equal(t, reference[2:2+len(page2)], page2, "page 2 must continue from page 1 cursor")
+		require.Equal(
+			t,
+			reference[2:2+len(page2)],
+			page2,
+			"page 2 must continue from page 1 cursor",
+		)
 	})
 
 	t.Run("WithSpendableOnly returns only spent=false AND unrolled=false", func(t *testing.T) {
@@ -121,7 +126,12 @@ func TestE2EVtxoPagination(t *testing.T) {
 		require.Empty(t, cursor)
 		require.Len(t, vtxos, 2, "expected 2 spent VTXOs")
 		for _, vtxo := range vtxos {
-			require.True(t, vtxo.Spent || vtxo.Unrolled, "outpoint %s must be spent or unrolled", outpointKey(vtxo))
+			require.True(
+				t,
+				vtxo.Spent || vtxo.Unrolled,
+				"outpoint %s must be spent or unrolled",
+				outpointKey(vtxo),
+			)
 		}
 	})
 
@@ -132,19 +142,33 @@ func TestE2EVtxoPagination(t *testing.T) {
 		require.Len(t, vtxos, 12, "expected all seeded VTXOs")
 	})
 
-	t.Run("WithAssetID filters to VTXOs holding the asset, but hydrates all their assets", func(t *testing.T) {
-		vtxos, cursor, err := f.alice.ListVtxos(
-			t.Context(), arksdk.WithAssetID(f.assetID), arksdk.WithLimit(1000),
-		)
-		require.NoError(t, err)
-		require.Empty(t, cursor)
-		require.Len(t, vtxos, 2, "expected exactly the two VTXOs holding asset %s", f.assetID)
-		for _, vtxo := range vtxos {
-			require.Positive(t, vtxo.Amount, "outpoint %s must carry BTC amount", outpointKey(vtxo))
-			requireAssetAmount(t, vtxo, f.assetID, 1)
-			require.Len(t, vtxo.Assets, 1, "outpoint %s should hydrate all issued assets", outpointKey(vtxo))
-		}
-	})
+	t.Run(
+		"WithAssetID filters to VTXOs holding the asset, but hydrates all their assets",
+		func(t *testing.T) {
+			vtxos, cursor, err := f.alice.ListVtxos(
+				t.Context(), arksdk.WithAssetID(f.assetID), arksdk.WithLimit(1000),
+			)
+			require.NoError(t, err)
+			require.Empty(t, cursor)
+			require.Len(t, vtxos, 2, "expected exactly the two VTXOs holding asset %s", f.assetID)
+			for _, vtxo := range vtxos {
+				require.Positive(
+					t,
+					vtxo.Amount,
+					"outpoint %s must carry BTC amount",
+					outpointKey(vtxo),
+				)
+				requireAssetAmount(t, vtxo, f.assetID, 1)
+				require.Len(
+					t,
+					vtxo.Assets,
+					1,
+					"outpoint %s should hydrate all issued assets",
+					outpointKey(vtxo),
+				)
+			}
+		},
+	)
 
 	t.Run("WithAssetID for non-existent asset returns empty", func(t *testing.T) {
 		vtxos, cursor, err := f.alice.ListVtxos(
@@ -166,13 +190,30 @@ func TestE2EVtxoPagination(t *testing.T) {
 				arksdk.WithCursor(cursor),
 			)
 			require.NoError(t, err)
-			require.LessOrEqual(t, len(page), 2, "page %d must contain VTXOs, not asset rows", pageIndex)
+			require.LessOrEqual(
+				t,
+				len(page),
+				2,
+				"page %d must contain VTXOs, not asset rows",
+				pageIndex,
+			)
 			for _, vtxo := range page {
 				if hasAsset(vtxo, f.assetID) {
 					found++
-					require.Positive(t, vtxo.Amount, "multi-asset outpoint %s must carry BTC amount", outpointKey(vtxo))
+					require.Positive(
+						t,
+						vtxo.Amount,
+						"multi-asset outpoint %s must carry BTC amount",
+						outpointKey(vtxo),
+					)
 					requireAssetAmount(t, vtxo, f.assetID, 1)
-					require.Len(t, vtxo.Assets, 1, "multi-asset outpoint %s assets were truncated", outpointKey(vtxo))
+					require.Len(
+						t,
+						vtxo.Assets,
+						1,
+						"multi-asset outpoint %s assets were truncated",
+						outpointKey(vtxo),
+					)
 				}
 			}
 			if next == "" {
@@ -211,14 +252,25 @@ func TestE2EVtxoPagination(t *testing.T) {
 		requireListVtxosOptionError(t, f.alice, arksdk.ErrInvalidLimit, arksdk.WithLimit(-1))
 	})
 
-	t.Run("WithSpendableOnly + WithSpentOnly returns ErrConflictingStatusOption", func(t *testing.T) {
-		requireListVtxosOptionError(
-			t, f.alice, arksdk.ErrConflictingStatusOption, arksdk.WithSpendableOnly(), arksdk.WithSpentOnly(),
-		)
-		requireListVtxosOptionError(
-			t, f.alice, arksdk.ErrConflictingStatusOption, arksdk.WithSpentOnly(), arksdk.WithSpendableOnly(),
-		)
-	})
+	t.Run(
+		"WithSpendableOnly + WithSpentOnly returns ErrConflictingStatusOption",
+		func(t *testing.T) {
+			requireListVtxosOptionError(
+				t,
+				f.alice,
+				arksdk.ErrConflictingStatusOption,
+				arksdk.WithSpendableOnly(),
+				arksdk.WithSpentOnly(),
+			)
+			requireListVtxosOptionError(
+				t,
+				f.alice,
+				arksdk.ErrConflictingStatusOption,
+				arksdk.WithSpentOnly(),
+				arksdk.WithSpendableOnly(),
+			)
+		},
+	)
 
 	t.Run("WithAssetID(empty) returns error", func(t *testing.T) {
 		vtxos, cursor, err := f.alice.ListVtxos(t.Context(), arksdk.WithAssetID(""))
@@ -229,7 +281,12 @@ func TestE2EVtxoPagination(t *testing.T) {
 	})
 
 	t.Run("WithCursor(malformed) returns ErrInvalidCursor", func(t *testing.T) {
-		requireListVtxosOptionError(t, f.alice, arksdk.ErrInvalidCursor, arksdk.WithCursor("not-base64-!!"))
+		requireListVtxosOptionError(
+			t,
+			f.alice,
+			arksdk.ErrInvalidCursor,
+			arksdk.WithCursor("not-base64-!!"),
+		)
 	})
 
 	t.Run("WithCursor(valid base64, malformed JSON) returns ErrInvalidCursor", func(t *testing.T) {
@@ -237,28 +294,36 @@ func TestE2EVtxoPagination(t *testing.T) {
 		requireListVtxosOptionError(t, f.alice, arksdk.ErrInvalidCursor, arksdk.WithCursor(cursor))
 	})
 
-	t.Run("WithCursor across different filter sets returns ErrCursorFilterMismatch", func(t *testing.T) {
-		_, cursor, err := f.alice.ListVtxos(
-			t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(2),
-		)
-		require.NoError(t, err)
-		require.NotEmpty(t, cursor, "first page should return a reusable cursor")
+	t.Run(
+		"WithCursor across different filter sets returns ErrCursorFilterMismatch",
+		func(t *testing.T) {
+			_, cursor, err := f.alice.ListVtxos(
+				t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(2),
+			)
+			require.NoError(t, err)
+			require.NotEmpty(t, cursor, "first page should return a reusable cursor")
 
-		requireListVtxosOptionError(
-			t,
-			f.alice,
-			arksdk.ErrCursorFilterMismatch,
-			arksdk.WithSpentOnly(),
-			arksdk.WithCursor(cursor),
-		)
-	})
+			requireListVtxosOptionError(
+				t,
+				f.alice,
+				arksdk.ErrCursorFilterMismatch,
+				arksdk.WithSpentOnly(),
+				arksdk.WithCursor(cursor),
+			)
+		},
+	)
 
 	t.Run("cursor stable when new VTXOs arrive between pages", func(t *testing.T) {
 		reference, _, err := f.alice.ListVtxos(
 			t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(1000),
 		)
 		require.NoError(t, err)
-		require.Len(t, reference, 10, "expected seeded spendable VTXO count before concurrent writes")
+		require.Len(
+			t,
+			reference,
+			10,
+			"expected seeded spendable VTXO count before concurrent writes",
+		)
 
 		page1, cursor, err := f.alice.ListVtxos(
 			t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(3),
@@ -281,7 +346,12 @@ func TestE2EVtxoPagination(t *testing.T) {
 		require.Equal(t, reference[3:6], page2, "page 2 must continue from the cursor anchor")
 		requireNoOutpointOverlap(t, page1, page2)
 		for _, newVtxo := range newVtxos {
-			require.NotContains(t, outpointSet(page2), outpointKey(newVtxo), "newer VTXO must not appear after cursor")
+			require.NotContains(
+				t,
+				outpointSet(page2),
+				outpointKey(newVtxo),
+				"newer VTXO must not appear after cursor",
+			)
 		}
 
 		walked := append(slices.Clone(page1), page2...)
@@ -349,7 +419,11 @@ func setupVtxoPaginationFixture(t *testing.T) vtxoPaginationFixture {
 	sendVtxos(t, bob, alice, 7, 1_500)
 
 	require.Eventually(t, func() bool {
-		spendable, _, err := alice.ListVtxos(ctx, arksdk.WithSpendableOnly(), arksdk.WithLimit(1000))
+		spendable, _, err := alice.ListVtxos(
+			ctx,
+			arksdk.WithSpendableOnly(),
+			arksdk.WithLimit(1000),
+		)
 		if err != nil || len(spendable) != 10 {
 			return false
 		}
@@ -386,7 +460,12 @@ func sendVtxos(
 			Amount: amount + uint64(i),
 		}})
 		vtxo := waitForVtxosAdded(t, vtxoCh, txid)
-		require.Positive(t, vtxo.Amount, "received VTXO %s must carry BTC amount", outpointKey(vtxo))
+		require.Positive(
+			t,
+			vtxo.Amount,
+			"received VTXO %s must carry BTC amount",
+			outpointKey(vtxo),
+		)
 		vtxos = append(vtxos, vtxo)
 		time.Sleep(vtxoPaginationSleep)
 	}
@@ -394,7 +473,11 @@ func sendVtxos(
 }
 
 // sendVtxoWithAsset sends one BTC carrier VTXO plus one issued-asset unit.
-func sendVtxoWithAsset(t *testing.T, sender, receiver arksdk.Wallet, assetID string) clientTypes.Vtxo {
+func sendVtxoWithAsset(
+	t *testing.T,
+	sender, receiver arksdk.Wallet,
+	assetID string,
+) clientTypes.Vtxo {
 	t.Helper()
 
 	ctx := t.Context()
@@ -564,7 +647,13 @@ func requireNoOutpointOverlap(t *testing.T, a, b []clientTypes.Vtxo) {
 
 	seen := outpointSet(a)
 	for _, vtxo := range b {
-		require.NotContains(t, seen, outpointKey(vtxo), "overlapping outpoint %s", outpointKey(vtxo))
+		require.NotContains(
+			t,
+			seen,
+			outpointKey(vtxo),
+			"overlapping outpoint %s",
+			outpointKey(vtxo),
+		)
 	}
 }
 

--- a/test/e2e/vtxo_pagination_test.go
+++ b/test/e2e/vtxo_pagination_test.go
@@ -1,0 +1,618 @@
+package e2e_test
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	clientTypes "github.com/arkade-os/arkd/pkg/client-lib/types"
+	arksdk "github.com/arkade-os/go-sdk"
+	sdktypes "github.com/arkade-os/go-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+const vtxoPaginationSleep = 50 * time.Millisecond
+
+type vtxoPaginationFixture struct {
+	alice   arksdk.Wallet
+	bob     arksdk.Wallet
+	assetID string
+}
+
+func TestE2EVtxoPagination(t *testing.T) {
+	f := setupVtxoPaginationFixture(t)
+
+	t.Run("paginated walk equals single-call result", func(t *testing.T) {
+		reference, cursor, err := f.alice.ListVtxos(
+			t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(1000),
+		)
+		require.NoError(t, err)
+		require.Empty(t, cursor, "limit 1000 should read all spendable VTXOs")
+		require.Len(t, reference, 10, "expected seeded spendable VTXO count")
+
+		limit := 3
+		pages, walked := walkVtxoPages(
+			t, f.alice, arksdk.WithSpendableOnly(), arksdk.WithLimit(limit),
+		)
+
+		requireOutpointSetEqual(t, reference, walked)
+		require.Equal(t, 4, pages)
+		require.Equal(t, 10, len(walked))
+		requireNoDuplicateOutpoints(t, walked)
+		require.GreaterOrEqual(t, pages*limit, len(reference), "pages*limit must cover reference count")
+		require.LessOrEqual(t, pages*limit, len(reference)+limit, "only the final page may be partial")
+	})
+
+	t.Run("end-of-pagination returns nil cursor", func(t *testing.T) {
+		var cursor string
+		var finalCursor string
+		for {
+			_, next, err := f.alice.ListVtxos(
+				t.Context(),
+				arksdk.WithSpendableOnly(),
+				arksdk.WithLimit(3),
+				arksdk.WithCursor(cursor),
+			)
+			require.NoError(t, err)
+			finalCursor = next
+			if next == "" {
+				break
+			}
+			cursor = next
+		}
+		require.Empty(t, finalCursor, "empty cursor must signal no more pages")
+	})
+
+	t.Run("limit greater than dataset returns nil cursor on first call", func(t *testing.T) {
+		vtxos, cursor, err := f.alice.ListVtxos(
+			t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(1000),
+		)
+		require.NoError(t, err)
+		require.Len(t, vtxos, 10, "expected all seeded spendable VTXOs")
+		require.Empty(t, cursor, "cursor must be empty when the first page exhausts the dataset")
+	})
+
+	t.Run("limit changes between pages", func(t *testing.T) {
+		reference, _, err := f.alice.ListVtxos(
+			t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(1000),
+		)
+		require.NoError(t, err)
+
+		page1, cursor, err := f.alice.ListVtxos(
+			t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(2),
+		)
+		require.NoError(t, err)
+		require.Len(t, page1, 2, "first page should use its requested limit")
+		require.NotEmpty(t, cursor, "first page should return a cursor")
+
+		page2, _, err := f.alice.ListVtxos(
+			t.Context(),
+			arksdk.WithSpendableOnly(),
+			arksdk.WithLimit(7),
+			arksdk.WithCursor(cursor),
+		)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(page2), 7, "second page must respect changed limit")
+		requireNoOutpointOverlap(t, page1, page2)
+		require.Equal(t, reference[2:2+len(page2)], page2, "page 2 must continue from page 1 cursor")
+	})
+
+	t.Run("WithSpendableOnly returns only spent=false AND unrolled=false", func(t *testing.T) {
+		vtxos, cursor, err := f.alice.ListVtxos(
+			t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(1000),
+		)
+		require.NoError(t, err)
+		require.Empty(t, cursor)
+		require.Len(t, vtxos, 10, "expected 10 spendable VTXOs")
+		for _, vtxo := range vtxos {
+			require.False(t, vtxo.Spent, "outpoint %s must not be spent", outpointKey(vtxo))
+			require.False(t, vtxo.Unrolled, "outpoint %s must not be unrolled", outpointKey(vtxo))
+		}
+	})
+
+	t.Run("WithSpentOnly returns only spent OR unrolled", func(t *testing.T) {
+		vtxos, cursor, err := f.alice.ListVtxos(
+			t.Context(), arksdk.WithSpentOnly(), arksdk.WithLimit(1000),
+		)
+		require.NoError(t, err)
+		require.Empty(t, cursor)
+		require.Len(t, vtxos, 2, "expected 2 spent VTXOs")
+		for _, vtxo := range vtxos {
+			require.True(t, vtxo.Spent || vtxo.Unrolled, "outpoint %s must be spent or unrolled", outpointKey(vtxo))
+		}
+	})
+
+	t.Run("default (no status filter) returns all 12", func(t *testing.T) {
+		vtxos, cursor, err := f.alice.ListVtxos(t.Context(), arksdk.WithLimit(1000))
+		require.NoError(t, err)
+		require.Empty(t, cursor)
+		require.Len(t, vtxos, 12, "expected all seeded VTXOs")
+	})
+
+	t.Run("WithAssetID filters to VTXOs holding the asset, but hydrates all their assets", func(t *testing.T) {
+		vtxos, cursor, err := f.alice.ListVtxos(
+			t.Context(), arksdk.WithAssetID(f.assetID), arksdk.WithLimit(1000),
+		)
+		require.NoError(t, err)
+		require.Empty(t, cursor)
+		require.Len(t, vtxos, 2, "expected exactly the two VTXOs holding asset %s", f.assetID)
+		for _, vtxo := range vtxos {
+			require.Positive(t, vtxo.Amount, "outpoint %s must carry BTC amount", outpointKey(vtxo))
+			requireAssetAmount(t, vtxo, f.assetID, 1)
+			require.Len(t, vtxo.Assets, 1, "outpoint %s should hydrate all issued assets", outpointKey(vtxo))
+		}
+	})
+
+	t.Run("WithAssetID for non-existent asset returns empty", func(t *testing.T) {
+		vtxos, cursor, err := f.alice.ListVtxos(
+			t.Context(), arksdk.WithAssetID("nonexistent-asset"), arksdk.WithLimit(1000),
+		)
+		require.NoError(t, err)
+		require.Empty(t, cursor)
+		require.Empty(t, vtxos)
+	})
+
+	t.Run("page boundary does not cut a multi-asset VTXO mid-way", func(t *testing.T) {
+		var cursor string
+		found := 0
+		for pageIndex := 1; ; pageIndex++ {
+			page, next, err := f.alice.ListVtxos(
+				t.Context(),
+				arksdk.WithSpendableOnly(),
+				arksdk.WithLimit(2),
+				arksdk.WithCursor(cursor),
+			)
+			require.NoError(t, err)
+			require.LessOrEqual(t, len(page), 2, "page %d must contain VTXOs, not asset rows", pageIndex)
+			for _, vtxo := range page {
+				if hasAsset(vtxo, f.assetID) {
+					found++
+					require.Positive(t, vtxo.Amount, "multi-asset outpoint %s must carry BTC amount", outpointKey(vtxo))
+					requireAssetAmount(t, vtxo, f.assetID, 1)
+					require.Len(t, vtxo.Assets, 1, "multi-asset outpoint %s assets were truncated", outpointKey(vtxo))
+				}
+			}
+			if next == "" {
+				break
+			}
+			cursor = next
+		}
+		require.Equal(t, 2, found, "expected both multi-asset VTXOs to be seen complete")
+	})
+
+	t.Run("WithSpendableOnly + WithAssetID + pagination", func(t *testing.T) {
+		_, vtxos := walkVtxoPages(
+			t,
+			f.alice,
+			arksdk.WithSpendableOnly(),
+			arksdk.WithAssetID(f.assetID),
+			arksdk.WithLimit(1),
+		)
+		require.Len(t, vtxos, 2, "expected two asset VTXOs across two pages")
+		for _, vtxo := range vtxos {
+			require.False(t, vtxo.Spent, "outpoint %s must be spendable", outpointKey(vtxo))
+			require.False(t, vtxo.Unrolled, "outpoint %s must be spendable", outpointKey(vtxo))
+			requireAssetAmount(t, vtxo, f.assetID, 1)
+		}
+	})
+
+	t.Run("WithLimit(0) returns ErrInvalidLimit", func(t *testing.T) {
+		requireListVtxosOptionError(t, f.alice, arksdk.ErrInvalidLimit, arksdk.WithLimit(0))
+	})
+
+	t.Run("WithLimit(1001) returns ErrInvalidLimit", func(t *testing.T) {
+		requireListVtxosOptionError(t, f.alice, arksdk.ErrInvalidLimit, arksdk.WithLimit(1001))
+	})
+
+	t.Run("WithLimit(-1) returns ErrInvalidLimit", func(t *testing.T) {
+		requireListVtxosOptionError(t, f.alice, arksdk.ErrInvalidLimit, arksdk.WithLimit(-1))
+	})
+
+	t.Run("WithSpendableOnly + WithSpentOnly returns ErrConflictingStatusOption", func(t *testing.T) {
+		requireListVtxosOptionError(
+			t, f.alice, arksdk.ErrConflictingStatusOption, arksdk.WithSpendableOnly(), arksdk.WithSpentOnly(),
+		)
+		requireListVtxosOptionError(
+			t, f.alice, arksdk.ErrConflictingStatusOption, arksdk.WithSpentOnly(), arksdk.WithSpendableOnly(),
+		)
+	})
+
+	t.Run("WithAssetID(empty) returns error", func(t *testing.T) {
+		vtxos, cursor, err := f.alice.ListVtxos(t.Context(), arksdk.WithAssetID(""))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "asset id must not be empty")
+		require.Nil(t, vtxos)
+		require.Empty(t, cursor)
+	})
+
+	t.Run("WithCursor(malformed) returns ErrInvalidCursor", func(t *testing.T) {
+		requireListVtxosOptionError(t, f.alice, arksdk.ErrInvalidCursor, arksdk.WithCursor("not-base64-!!"))
+	})
+
+	t.Run("WithCursor(valid base64, malformed JSON) returns ErrInvalidCursor", func(t *testing.T) {
+		cursor := base64.RawURLEncoding.EncodeToString([]byte("not json"))
+		requireListVtxosOptionError(t, f.alice, arksdk.ErrInvalidCursor, arksdk.WithCursor(cursor))
+	})
+
+	t.Run("WithCursor across different filter sets returns ErrCursorFilterMismatch", func(t *testing.T) {
+		_, cursor, err := f.alice.ListVtxos(
+			t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(2),
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, cursor, "first page should return a reusable cursor")
+
+		requireListVtxosOptionError(
+			t,
+			f.alice,
+			arksdk.ErrCursorFilterMismatch,
+			arksdk.WithSpentOnly(),
+			arksdk.WithCursor(cursor),
+		)
+	})
+
+	t.Run("cursor stable when new VTXOs arrive between pages", func(t *testing.T) {
+		reference, _, err := f.alice.ListVtxos(
+			t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(1000),
+		)
+		require.NoError(t, err)
+		require.Len(t, reference, 10, "expected seeded spendable VTXO count before concurrent writes")
+
+		page1, cursor, err := f.alice.ListVtxos(
+			t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(3),
+		)
+		require.NoError(t, err)
+		require.Len(t, page1, 3, "expected first page size")
+		require.NotEmpty(t, cursor, "first page should return cursor")
+
+		waitAfterVtxoCreatedAt(page1[0])
+		newVtxos := sendVtxos(t, f.bob, f.alice, 2, 2_000)
+
+		page2, nextCursor, err := f.alice.ListVtxos(
+			t.Context(),
+			arksdk.WithSpendableOnly(),
+			arksdk.WithLimit(3),
+			arksdk.WithCursor(cursor),
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, nextCursor, "second page should still have a cursor")
+		require.Equal(t, reference[3:6], page2, "page 2 must continue from the cursor anchor")
+		requireNoOutpointOverlap(t, page1, page2)
+		for _, newVtxo := range newVtxos {
+			require.NotContains(t, outpointSet(page2), outpointKey(newVtxo), "newer VTXO must not appear after cursor")
+		}
+
+		walked := append(slices.Clone(page1), page2...)
+		cursor = nextCursor
+		for cursor != "" {
+			page, next, err := f.alice.ListVtxos(
+				t.Context(),
+				arksdk.WithSpendableOnly(),
+				arksdk.WithLimit(3),
+				arksdk.WithCursor(cursor),
+			)
+			require.NoError(t, err)
+			walked = append(walked, page...)
+			cursor = next
+		}
+
+		current, _, err := f.alice.ListVtxos(
+			t.Context(), arksdk.WithSpendableOnly(), arksdk.WithLimit(1000),
+		)
+		require.NoError(t, err)
+		require.Len(t, current, 12, "expected 10 original plus 2 new spendable VTXOs")
+		walkedPlusNew := append(slices.Clone(walked), newVtxos...)
+		requireOutpointSetEqual(t, current, walkedPlusNew)
+	})
+}
+
+// setupVtxoPaginationFixture builds Alice's pagination dataset:
+//   - 2 VTXOs are received first, then settled, leaving them spent.
+//   - the settlement creates 1 spendable VTXO.
+//   - 2 spendable VTXOs with assets are received next.
+//   - 7 more spendable VTXOs are received last.
+//
+// Final Alice state: 12 VTXOs total, 10 spendable, 2 spent, with the
+// asset VTXOs inside the spendable set. Sends are separated by short sleeps
+// so second-resolution created_at ordering remains deterministic.
+func setupVtxoPaginationFixture(t *testing.T) vtxoPaginationFixture {
+	t.Helper()
+
+	ctx := t.Context()
+	alice := setupClient(t, "", arksdk.WithoutAutoSettle())
+	bob := setupClient(t, "", arksdk.WithoutAutoSettle())
+
+	faucetOffchain(t, bob, 0.02)
+
+	sendVtxos(t, bob, alice, 2, 1_500)
+
+	aliceVtxoCh := alice.GetVtxoEventChannel(ctx)
+	_, err := alice.Settle(ctx)
+	require.NoError(t, err)
+	waitForVtxosAdded(t, aliceVtxoCh, "")
+
+	_, assetIDs, err := bob.IssueAsset(ctx, 2, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, assetIDs, 1)
+	assetID := assetIDs[0].String()
+	require.Eventually(t, func() bool {
+		vtxos, _, err := bob.ListVtxos(ctx, arksdk.WithAssetID(assetID), arksdk.WithLimit(1000))
+		return err == nil && len(vtxos) == 1 && hasAssetAmount(vtxos[0], assetID, 2)
+	}, 10*time.Second, 100*time.Millisecond, "bob should index issued asset %s", assetID)
+
+	sendVtxoWithAsset(t, bob, alice, assetID)
+	// Wait for Bob's asset change before spending it in the second asset send.
+	requireSpendableAssetVtxos(t, bob, assetID, 1, 1)
+	sendVtxoWithAsset(t, bob, alice, assetID)
+	sendVtxos(t, bob, alice, 7, 1_500)
+
+	require.Eventually(t, func() bool {
+		spendable, _, err := alice.ListVtxos(ctx, arksdk.WithSpendableOnly(), arksdk.WithLimit(1000))
+		if err != nil || len(spendable) != 10 {
+			return false
+		}
+		spent, _, err := alice.ListVtxos(ctx, arksdk.WithSpentOnly(), arksdk.WithLimit(1000))
+		if err != nil || len(spent) != 2 {
+			return false
+		}
+		all, _, err := alice.ListVtxos(ctx, arksdk.WithLimit(1000))
+		return err == nil && len(all) == 12
+	}, 10*time.Second, 100*time.Millisecond, "pagination fixture should have 10 spendable, 2 spent, 12 total VTXOs")
+
+	return vtxoPaginationFixture{
+		alice:   alice,
+		bob:     bob,
+		assetID: assetID,
+	}
+}
+
+// sendVtxos sends count BTC-only VTXOs and waits for each receiver-side event.
+func sendVtxos(
+	t *testing.T, sender, receiver arksdk.Wallet, count int, amount uint64,
+) []clientTypes.Vtxo {
+	t.Helper()
+
+	ctx := t.Context()
+	addr, err := receiver.NewOffchainAddress(ctx)
+	require.NoError(t, err)
+
+	vtxoCh := receiver.GetVtxoEventChannel(ctx)
+	vtxos := make([]clientTypes.Vtxo, 0, count)
+	for i := range count {
+		txid := sendOffchainEventually(t, sender, []clientTypes.Receiver{{
+			To:     addr,
+			Amount: amount + uint64(i),
+		}})
+		vtxo := waitForVtxosAdded(t, vtxoCh, txid)
+		require.Positive(t, vtxo.Amount, "received VTXO %s must carry BTC amount", outpointKey(vtxo))
+		vtxos = append(vtxos, vtxo)
+		time.Sleep(vtxoPaginationSleep)
+	}
+	return vtxos
+}
+
+// sendVtxoWithAsset sends one BTC carrier VTXO plus one issued-asset unit.
+func sendVtxoWithAsset(t *testing.T, sender, receiver arksdk.Wallet, assetID string) clientTypes.Vtxo {
+	t.Helper()
+
+	ctx := t.Context()
+	addr, err := receiver.NewOffchainAddress(ctx)
+	require.NoError(t, err)
+
+	vtxoCh := receiver.GetVtxoEventChannel(ctx)
+	txid := sendOffchainEventually(t, sender, []clientTypes.Receiver{{
+		To:     addr,
+		Amount: 1_500,
+		Assets: []clientTypes.Asset{{
+			AssetId: assetID,
+			Amount:  1,
+		}},
+	}})
+	vtxo := waitForVtxosAdded(t, vtxoCh, txid)
+	require.Positive(t, vtxo.Amount, "received VTXO %s must carry BTC amount", outpointKey(vtxo))
+	requireAssetAmount(t, vtxo, assetID, 1)
+	time.Sleep(vtxoPaginationSleep)
+	return vtxo
+}
+
+// sendOffchainEventually retries while arkd/indexer catches up with new inputs.
+func sendOffchainEventually(
+	t *testing.T, sender arksdk.Wallet, receivers []clientTypes.Receiver,
+) string {
+	t.Helper()
+
+	var txid string
+	var lastErr error
+	require.Eventually(t, func() bool {
+		var err error
+		txid, err = sender.SendOffChain(t.Context(), receivers)
+		if err != nil {
+			lastErr = err
+			return false
+		}
+		return true
+	}, 10*time.Second, 250*time.Millisecond, "SendOffChain should succeed, last error: %v", lastErr)
+	require.NotEmpty(t, txid)
+	return txid
+}
+
+// waitForVtxosAdded waits for a receiver-side added event matching txid.
+func waitForVtxosAdded(
+	t *testing.T, ch <-chan sdktypes.VtxoEvent, txid string,
+) clientTypes.Vtxo {
+	t.Helper()
+
+	timeout := time.After(10 * time.Second)
+	for {
+		select {
+		case event := <-ch:
+			if event.Type != sdktypes.VtxosAdded || len(event.Vtxos) == 0 {
+				continue
+			}
+			for _, vtxo := range event.Vtxos {
+				if txid == "" || vtxo.Txid == txid {
+					return vtxo
+				}
+			}
+		case <-timeout:
+			require.FailNow(t, "timed out waiting for VtxosAdded", "txid=%s", txid)
+		}
+	}
+}
+
+// requireSpendableAssetVtxos waits until asset change is indexed as spendable.
+func requireSpendableAssetVtxos(
+	t *testing.T, wallet arksdk.Wallet, assetID string, count int, amount uint64,
+) {
+	t.Helper()
+
+	// Asset sends create asset change; wait until it is indexed as spendable.
+	require.Eventually(t, func() bool {
+		vtxos, _, err := wallet.ListVtxos(
+			t.Context(),
+			arksdk.WithSpendableOnly(),
+			arksdk.WithAssetID(assetID),
+			arksdk.WithLimit(1000),
+		)
+		if err != nil || len(vtxos) != count {
+			return false
+		}
+		for _, vtxo := range vtxos {
+			if !hasAssetAmount(vtxo, assetID, amount) {
+				return false
+			}
+		}
+		return true
+	}, 10*time.Second, 100*time.Millisecond, "wallet should have %d spendable VTXOs with asset %s amount %d", count, assetID, amount)
+}
+
+// waitAfterVtxoCreatedAt ensures later writes sort after the cursor anchor.
+func waitAfterVtxoCreatedAt(vtxo clientTypes.Vtxo) {
+	for time.Now().Unix() <= vtxo.CreatedAt.Unix() {
+		time.Sleep(vtxoPaginationSleep)
+	}
+}
+
+// walkVtxoPages follows cursors until the empty-cursor end signal.
+func walkVtxoPages(
+	t *testing.T, wallet arksdk.Wallet, opts ...arksdk.ListVtxosOption,
+) (int, []clientTypes.Vtxo) {
+	t.Helper()
+
+	var cursor string
+	var pages int
+	var all []clientTypes.Vtxo
+	for {
+		pageOpts := append(slices.Clone(opts), arksdk.WithCursor(cursor))
+		page, next, err := wallet.ListVtxos(t.Context(), pageOpts...)
+		require.NoError(t, err)
+		pages++
+		all = append(all, page...)
+		if next == "" {
+			return pages, all
+		}
+		cursor = next
+	}
+}
+
+// requireListVtxosOptionError verifies invalid options return no page data.
+func requireListVtxosOptionError(
+	t *testing.T, wallet arksdk.Wallet, target error, opts ...arksdk.ListVtxosOption,
+) {
+	t.Helper()
+
+	vtxos, cursor, err := wallet.ListVtxos(t.Context(), opts...)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, target), "expected %v, got %v", target, err)
+	require.Nil(t, vtxos)
+	require.Empty(t, cursor)
+}
+
+// requireOutpointSetEqual compares VTXO slices by outpoint identity.
+func requireOutpointSetEqual(t *testing.T, expected, actual []clientTypes.Vtxo) {
+	t.Helper()
+
+	expectedSet := outpointSet(expected)
+	actualSet := outpointSet(actual)
+	require.Equal(
+		t,
+		expectedSet,
+		actualSet,
+		"outpoint set mismatch: expected %d VTXOs, got %d VTXOs",
+		len(expected),
+		len(actual),
+	)
+}
+
+// requireNoDuplicateOutpoints catches repeated VTXOs across paginated pages.
+func requireNoDuplicateOutpoints(t *testing.T, vtxos []clientTypes.Vtxo) {
+	t.Helper()
+
+	seen := make(map[string]struct{}, len(vtxos))
+	for _, vtxo := range vtxos {
+		key := outpointKey(vtxo)
+		require.NotContains(t, seen, key, "duplicate outpoint %s", key)
+		seen[key] = struct{}{}
+	}
+}
+
+// requireNoOutpointOverlap verifies adjacent pages do not share VTXOs.
+func requireNoOutpointOverlap(t *testing.T, a, b []clientTypes.Vtxo) {
+	t.Helper()
+
+	seen := outpointSet(a)
+	for _, vtxo := range b {
+		require.NotContains(t, seen, outpointKey(vtxo), "overlapping outpoint %s", outpointKey(vtxo))
+	}
+}
+
+// requireAssetAmount checks the hydrated asset amount on a VTXO.
+func requireAssetAmount(t *testing.T, vtxo clientTypes.Vtxo, assetID string, amount uint64) {
+	t.Helper()
+
+	require.True(
+		t,
+		hasAssetAmount(vtxo, assetID, amount),
+		"outpoint %s expected asset %s amount %d in assets %+v",
+		outpointKey(vtxo),
+		assetID,
+		amount,
+		vtxo.Assets,
+	)
+}
+
+// hasAsset reports whether the VTXO contains the requested asset.
+func hasAsset(vtxo clientTypes.Vtxo, assetID string) bool {
+	for _, asset := range vtxo.Assets {
+		if asset.AssetId == assetID {
+			return true
+		}
+	}
+	return false
+}
+
+// hasAssetAmount reports whether the VTXO contains the requested asset amount.
+func hasAssetAmount(vtxo clientTypes.Vtxo, assetID string, amount uint64) bool {
+	for _, asset := range vtxo.Assets {
+		if asset.AssetId == assetID && asset.Amount == amount {
+			return true
+		}
+	}
+	return false
+}
+
+// outpointSet converts VTXOs into a txid:vout keyed set.
+func outpointSet(vtxos []clientTypes.Vtxo) map[string]struct{} {
+	set := make(map[string]struct{}, len(vtxos))
+	for _, vtxo := range vtxos {
+		set[outpointKey(vtxo)] = struct{}{}
+	}
+	return set
+}
+
+// outpointKey returns the stable VTXO identity used in assertions.
+func outpointKey(vtxo clientTypes.Vtxo) string {
+	return fmt.Sprintf("%s:%d", vtxo.Txid, vtxo.VOut)
+}

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -7,6 +7,38 @@ import (
 	"github.com/arkade-os/arkd/pkg/client-lib/types"
 )
 
+// VtxoStatusFilter narrows GetVtxos results by spend/unroll state.
+type VtxoStatusFilter int
+
+const (
+	VtxoStatusAll       VtxoStatusFilter = iota // no status filter
+	VtxoStatusSpendable                         // spent = false AND unrolled = false
+	VtxoStatusSpent                             // spent = true OR unrolled = true
+)
+
+// GetVtxoFilter defines all filters that can be applied to a GetVtxos request.
+type GetVtxoFilter struct {
+	Status  VtxoStatusFilter
+	AssetID string  // "" = no asset filter
+	After   *Cursor // nil = first page
+	Limit   int     // number of VTXOs to return
+}
+
+// Cursor is the cursor position in the (created_at DESC, txid DESC, vout DESC)
+// sort order.
+type Cursor struct {
+	CreatedAt int64
+	Txid      string
+	VOut      uint32
+}
+
+// VtxoPageResult is the typed page response from VtxoStore.GetVtxos.
+// Next is nil when there is no further page.
+type VtxoPageResult struct {
+	Vtxos []types.Vtxo
+	Next  *Cursor
+}
+
 type Store interface {
 	TransactionStore() TransactionStore
 	UtxoStore() UtxoStore
@@ -52,9 +84,20 @@ type VtxoStore interface {
 	) (int, error)
 	SweepVtxos(ctx context.Context, vtxosToSweep []types.Vtxo) (int, error)
 	UnrollVtxos(ctx context.Context, vtxosToUnroll []types.Vtxo) (int, error)
-	GetAllVtxos(ctx context.Context) (spendable, spent []types.Vtxo, err error)
-	GetSpendableVtxos(ctx context.Context) ([]types.Vtxo, error)
-	GetVtxos(ctx context.Context, keys []types.Outpoint) ([]types.Vtxo, error)
+
+	// GetSpendableOrRecoverableVtxos returns all VTXOs where spent = false AND
+	// unrolled = false. This is the union of strictly spendable VTXOs and
+	// recoverable VTXOs (swept or expired, but not spent). Callers needing to
+	// distinguish use IsRecoverable on each returned VTXO.
+	GetSpendableOrRecoverableVtxos(ctx context.Context) ([]types.Vtxo, error)
+
+	// GetVtxosByOutpoints returns VTXOs matching the given outpoints.
+	GetVtxosByOutpoints(ctx context.Context, keys []types.Outpoint) ([]types.Vtxo, error)
+
+	// GetVtxos returns a single page of VTXOs according to q. Used by the
+	// public Wallet.ListVtxos paginated API.
+	GetVtxos(ctx context.Context, q GetVtxoFilter) ([]types.Vtxo, *Cursor, error)
+
 	Clean(ctx context.Context) error
 	GetEventChannel() <-chan VtxoEvent
 }

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -94,8 +94,9 @@ type VtxoStore interface {
 	// GetVtxosByOutpoints returns VTXOs matching the given outpoints.
 	GetVtxosByOutpoints(ctx context.Context, keys []types.Outpoint) ([]types.Vtxo, error)
 
-	// GetVtxos returns a single page of VTXOs according to q. Used by the
-	// public Wallet.ListVtxos paginated API.
+	// GetVtxos returns one page of VTXOs according to q. When the returned
+	// cursor is nil, the page is the end of the result set. The cursor is an
+	// internal keyset position used by the public Wallet.ListVtxos API.
 	GetVtxos(ctx context.Context, q GetVtxoFilter) ([]types.Vtxo, *Cursor, error)
 
 	Clean(ctx context.Context) error

--- a/wallet.go
+++ b/wallet.go
@@ -807,7 +807,7 @@ func (w *wallet) refreshVtxoDb(
 	ctx context.Context, spendableVtxos, spentVtxos []clienttypes.Vtxo,
 ) error {
 	// Fetch old data.
-	oldSpendableVtxos, _, err := w.store.VtxoStore().GetAllVtxos(ctx)
+	oldSpendableVtxos, err := w.store.VtxoStore().GetSpendableOrRecoverableVtxos(ctx)
 	if err != nil {
 		return err
 	}
@@ -1347,7 +1347,7 @@ func (w *wallet) handleCommitmentTx(
 			indexedSpentVtxos[vtxo.Outpoint] = vtxo
 		}
 	}
-	myVtxos, err := w.store.VtxoStore().GetVtxos(ctx, spentVtxos)
+	myVtxos, err := w.store.VtxoStore().GetVtxosByOutpoints(ctx, spentVtxos)
 	if err != nil {
 		return err
 	}
@@ -1526,7 +1526,7 @@ func (w *wallet) handleArkTx(
 			VOut: vtxo.VOut,
 		})
 	}
-	myVtxos, err := w.store.VtxoStore().GetVtxos(ctx, spentVtxos)
+	myVtxos, err := w.store.VtxoStore().GetVtxosByOutpoints(ctx, spentVtxos)
 	if err != nil {
 		return err
 	}
@@ -1625,7 +1625,7 @@ func (w *wallet) handleSweepTx(ctx context.Context, sweepTx *client.TxNotificati
 		return nil
 	}
 
-	myVtxos, err := w.store.VtxoStore().GetVtxos(ctx, sweepTx.SweptVtxos)
+	myVtxos, err := w.store.VtxoStore().GetVtxosByOutpoints(ctx, sweepTx.SweptVtxos)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This adds cursor-based pagination option to ListVtxos:
- the cursor represents the first vtxo of the very next page.
- page size (Limit) can be customized at will between pages. Defaults to max value (1000) and can assume any value in range [1, 1000].
- to correctly implement pagination, the db always orders vtxos by creation time (+ vtxo oupoint to resolve deterministically if many vtxos have the same creation time) DESC, and it's non-sensitive to insertions happening while retrieving pages.
- adds tests for the new pagination system

Please @sekulicd review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter VTXO listings by spendable/spent status and asset ID.
  * Cursor-based pagination for VTXO listings with opaque next-page tokens.
  * Database index added to speed VTXO queries.

* **Breaking Changes**
  * VTXO listing API now accepts filter/options and returns a paginated cursor instead of separate spendable/spent lists.

* **Tests**
  * Expanded unit and end-to-end tests covering pagination, filters, cursor validation, and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/go-sdk/pull/178)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->