### PR TITLE
Allow registering custom contract handlers

### DIFF
--- a/contract/doc.go
+++ b/contract/doc.go
@@ -81,15 +81,24 @@
 //
 // # Extending with new contract types
 //
-// New handler kinds (vhtlc, delegate, …) plug in by:
+// New handler kinds (vhtlc, delegate, custom user-defined contracts, …)
+// plug in by:
 //  1. Implementing handlers.Handler (see contract/handlers/handler.go).
-//  2. Registering the handler in NewManager's handlers map under a new
+//  2. Registering the handler with the manager. Two equivalent paths:
+//     - At construction, via Args.ExtraHandlers, keyed by a new
 //     types.ContractType.
+//     - At runtime, via [Manager.RegisterHandler].
+//     Both reject empty types, nil handlers, and any type that is already
+//     registered (including the built-in default and boarding types).
 //  3. If the new type's "has this contract been used externally?" probe
 //     differs from the indexer or explorer paths the dispatcher already
 //     knows about, adding a branch in ScanContracts that selects the
-//     correct findUsedFn.
+//     correct findUsedFn. By default ScanContracts uses the indexer
+//     (offchain) path for any non-boarding type.
 //
-// The handler map is presently hardcoded in NewManager — see the TODOs
-// there for the eventual move to a registry callers can extend.
+// User-registered handlers are responsible for their own client caching.
+// The manager wraps args.Client with a shared GetInfo cache and hands the
+// wrapped client to the built-in handlers only — handlers constructed by
+// callers were built before the manager existed and need not depend on
+// client.Client at all.
 package contract

--- a/contract/doc.go
+++ b/contract/doc.go
@@ -27,9 +27,11 @@
 //
 //   - infoCache (see info_cache.go) memoizes client.Client.GetInfo
 //     responses. NewManager wraps args.Client once with a cachingClient
-//     and hands the wrapped client to every registered handler, so all
-//     handlers (and any future vhtlc/delegate kinds) share a single
-//     GetInfo cache rather than fanning one out per handler.
+//     and hands the wrapped client to every built-in handler, so they
+//     share a single GetInfo cache rather than fanning one out per
+//     handler. Handlers supplied by callers via Args.ExtraHandlers or
+//     Manager.RegisterHandler were constructed outside the manager and
+//     own their own client wiring — see the extension section below.
 //
 //   - keyProvider (unexported, defined in types.go) is the subset of the
 //     identity.Identity surface the manager needs to derive contracts:

--- a/contract/doc.go
+++ b/contract/doc.go
@@ -78,8 +78,9 @@
 //
 // The manager guards its handler map with an [sync.RWMutex]. Lookups
 // (GetContracts, GetHandler, GetSupportedContractTypes) hold a read lock;
-// mutations (NewContract, ScanContracts, Clean, Close) hold the write
-// lock. The store and the info cache have their own internal locking.
+// mutations (NewContract, ScanContracts, RegisterHandler, Clean, Close)
+// hold the write lock. The store and the info cache have their own
+// internal locking.
 //
 // # Extending with new contract types
 //

--- a/contract/fake_handler_test.go
+++ b/contract/fake_handler_test.go
@@ -1,0 +1,85 @@
+package contract_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/client-lib/identity"
+	"github.com/arkade-os/go-sdk/contract/handlers"
+	"github.com/arkade-os/go-sdk/types"
+	"github.com/btcsuite/btcd/btcec/v2"
+)
+
+// fakeHandler is a minimal handlers.Handler used by the registry tests so
+// they don't depend on the default/boarding handlers' wiring (transport
+// client, network, etc.). It produces a deterministic contract from a
+// keyRef so the scan-loop tests can predict scripts and stage indexer
+// hits the same way the default-handler tests do.
+type fakeHandler struct {
+	typ       types.ContractType
+	exitDelay arklib.RelativeLocktime
+}
+
+func newFakeHandler(typ types.ContractType) *fakeHandler {
+	return &fakeHandler{
+		typ: typ,
+		exitDelay: arklib.RelativeLocktime{
+			Type:  arklib.LocktimeTypeSecond,
+			Value: 144,
+		},
+	}
+}
+
+func (h *fakeHandler) NewContract(
+	_ context.Context, keyRef identity.KeyRef,
+) (*types.Contract, error) {
+	script := fakeScript(h.typ, keyRef.Id)
+	return &types.Contract{
+		Type:    h.typ,
+		State:   types.ContractStateActive,
+		Script:  script,
+		Address: "fake:" + script,
+		Params: map[string]string{
+			ownerKeyIdParam: keyRef.Id,
+		},
+	}, nil
+}
+
+func (h *fakeHandler) GetKeyRefs(c types.Contract) (map[string]string, error) {
+	return map[string]string{ownerKeyIdParam: c.Params[ownerKeyIdParam]}, nil
+}
+
+func (h *fakeHandler) GetKeyRef(c types.Contract) (*identity.KeyRef, error) {
+	id, ok := c.Params[ownerKeyIdParam]
+	if !ok {
+		return nil, fmt.Errorf("missing %s in params", ownerKeyIdParam)
+	}
+	return &identity.KeyRef{Id: id}, nil
+}
+
+func (h *fakeHandler) GetSignerKey(_ types.Contract) (*btcec.PublicKey, error) {
+	return nil, nil
+}
+
+func (h *fakeHandler) GetExitDelay(_ types.Contract) (*arklib.RelativeLocktime, error) {
+	d := h.exitDelay
+	return &d, nil
+}
+
+func (h *fakeHandler) GetTapscripts(_ types.Contract) ([]string, error) {
+	return nil, nil
+}
+
+// fakeScript mirrors fakeHandler.NewContract so tests can predict the
+// script a given (type, keyId) pair will produce without going through the
+// handler.
+func fakeScript(typ types.ContractType, keyId string) string {
+	h := sha256.Sum256([]byte(string(typ) + ":" + keyId))
+	return hex.EncodeToString(h[:])
+}
+
+// compile-time check that fakeHandler satisfies the Handler interface.
+var _ handlers.Handler = (*fakeHandler)(nil)

--- a/contract/manager.go
+++ b/contract/manager.go
@@ -60,9 +60,23 @@ func NewManager(args Args) (Manager, error) {
 	}, nil
 }
 
+// builtInContractTypes is the set of types NewManager registers itself.
+// Used by validateHandlerRegistration to give a more specific error when a
+// caller tries to override one of them.
+var builtInContractTypes = map[types.ContractType]struct{}{
+	types.ContractTypeDefault:  {},
+	types.ContractTypeBoarding: {},
+}
+
 // validateHandlerRegistration enforces the rules a handler must satisfy to
 // join the registry: non-empty type, non-nil handler, and no collision with
-// a type already registered (which includes the built-ins).
+// a type already registered (built-in or previously registered custom).
+//
+// The nil-handler check catches a literal nil interface only; a non-nil
+// interface holding a nil concrete pointer will pass and nil-deref on the
+// first dispatched call. Construct handlers via their named constructors
+// (e.g. defaultHandler.NewHandler) rather than passing through a typed-nil
+// variable.
 func validateHandlerRegistration(
 	registered map[types.ContractType]handlers.Handler,
 	typ types.ContractType, h handlers.Handler,
@@ -72,6 +86,9 @@ func validateHandlerRegistration(
 	}
 	if h == nil {
 		return fmt.Errorf("nil handler for contract type %s", typ)
+	}
+	if _, isBuiltIn := builtInContractTypes[typ]; isBuiltIn {
+		return fmt.Errorf("contract type %s is reserved by a built-in handler", typ)
 	}
 	if _, ok := registered[typ]; ok {
 		return fmt.Errorf("contract type %s is already registered", typ)

--- a/contract/manager.go
+++ b/contract/manager.go
@@ -24,9 +24,8 @@ type contractManager struct {
 	indexer     offchainDataProvider
 	explorer    onchainDataProvider
 	network     arklib.Network
-	// TODO: this must become a registry so that users can register their custom handlers at will.
-	handlers map[types.ContractType]handlers.Handler
-	mu       sync.RWMutex
+	handlers    map[types.ContractType]handlers.Handler
+	mu          sync.RWMutex
 }
 
 func NewManager(args Args) (Manager, error) {
@@ -34,25 +33,50 @@ func NewManager(args Args) (Manager, error) {
 		return nil, err
 	}
 	// Wrap the transport client once with a shared GetInfo cache so all
-	// handlers (default, boarding, and any future vhtlc/delegate kinds)
-	// reuse the same cached server info instead of fanning out a
-	// per-handler cache.
+	// built-in handlers (default, boarding) reuse the same cached server
+	// info instead of fanning out a per-handler cache. Caller-supplied
+	// handlers in ExtraHandlers are responsible for their own caching:
+	// they were constructed outside the manager and we cannot assume they
+	// take a client.Client at all.
 	cachedClient := newCachingClient(args.Client, newInfoCache(infoCacheTTL))
-	// TODO: 1. support also delegate and vhtlc handlers
-	// TODO: 2. make use of a register to allow extending the contract manager with custom handlers
-	handlers := map[types.ContractType]handlers.Handler{
+	hs := map[types.ContractType]handlers.Handler{
 		types.ContractTypeDefault:  defaultHandler.NewHandler(cachedClient, args.Network, false),
 		types.ContractTypeBoarding: defaultHandler.NewHandler(cachedClient, args.Network, true),
+	}
+	for typ, h := range args.ExtraHandlers {
+		if err := validateHandlerRegistration(hs, typ, h); err != nil {
+			return nil, fmt.Errorf("invalid extra handler: %w", err)
+		}
+		hs[typ] = h
 	}
 	return &contractManager{
 		store:       args.Store,
 		keyProvider: args.KeyProvider,
 		indexer:     args.Indexer,
 		explorer:    args.Explorer,
-		handlers:    handlers,
+		handlers:    hs,
 		network:     args.Network,
 		mu:          sync.RWMutex{},
 	}, nil
+}
+
+// validateHandlerRegistration enforces the rules a handler must satisfy to
+// join the registry: non-empty type, non-nil handler, and no collision with
+// a type already registered (which includes the built-ins).
+func validateHandlerRegistration(
+	registered map[types.ContractType]handlers.Handler,
+	typ types.ContractType, h handlers.Handler,
+) error {
+	if len(typ) == 0 {
+		return fmt.Errorf("missing contract type")
+	}
+	if h == nil {
+		return fmt.Errorf("nil handler for contract type %s", typ)
+	}
+	if _, ok := registered[typ]; ok {
+		return fmt.Errorf("contract type %s is already registered", typ)
+	}
+	return nil
 }
 
 func (m *contractManager) ScanContracts(ctx context.Context, gapLimit uint32) error {
@@ -164,6 +188,21 @@ func (m *contractManager) GetHandler(
 		return nil, fmt.Errorf("unsupported contract type: %s", contract.Type)
 	}
 	return handler, nil
+}
+
+func (m *contractManager) RegisterHandler(
+	_ context.Context, contractType types.ContractType, handler handlers.Handler,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err := validateHandlerRegistration(m.handlers, contractType, handler); err != nil {
+		return err
+	}
+	m.handlers[contractType] = handler
+
+	log.Debugf("%s registered handler for contract type %s", logPrefix, contractType)
+	return nil
 }
 
 func (m *contractManager) Clean(ctx context.Context) error {

--- a/contract/manager.go
+++ b/contract/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"reflect"
 	"slices"
 	"sync"
 	"time"
@@ -69,14 +70,9 @@ var builtInContractTypes = map[types.ContractType]struct{}{
 }
 
 // validateHandlerRegistration enforces the rules a handler must satisfy to
-// join the registry: non-empty type, non-nil handler, and no collision with
-// a type already registered (built-in or previously registered custom).
-//
-// The nil-handler check catches a literal nil interface only; a non-nil
-// interface holding a nil concrete pointer will pass and nil-deref on the
-// first dispatched call. Construct handlers via their named constructors
-// (e.g. defaultHandler.NewHandler) rather than passing through a typed-nil
-// variable.
+// join the registry: non-empty type, non-nil handler (including a typed-nil
+// concrete value behind a non-nil interface), and no collision with a type
+// already registered (built-in or previously registered custom).
 func validateHandlerRegistration(
 	registered map[types.ContractType]handlers.Handler,
 	typ types.ContractType, h handlers.Handler,
@@ -86,6 +82,20 @@ func validateHandlerRegistration(
 	}
 	if h == nil {
 		return fmt.Errorf("nil handler for contract type %s", typ)
+	}
+	// A non-nil interface can still hold a nil concrete value (e.g. an
+	// uninitialized *fakeHandler typed as handlers.Handler). Such a handler
+	// would pass the h == nil check above and nil-deref on the first
+	// dispatched call. Reflect on the concrete value and reject the
+	// nilable-kind-with-nil-value case.
+	if v := reflect.ValueOf(h); v.IsValid() {
+		switch v.Kind() {
+		case reflect.Ptr, reflect.Slice, reflect.Map,
+			reflect.Func, reflect.Chan, reflect.Interface:
+			if v.IsNil() {
+				return fmt.Errorf("nil concrete handler for contract type %s", typ)
+			}
+		}
 	}
 	if _, isBuiltIn := builtInContractTypes[typ]; isBuiltIn {
 		return fmt.Errorf("contract type %s is reserved by a built-in handler", typ)

--- a/contract/manager_test.go
+++ b/contract/manager_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/arkade-os/go-sdk/contract"
 	"github.com/arkade-os/go-sdk/contract/handlers"
-	"github.com/arkade-os/go-sdk/store"
 	"github.com/arkade-os/go-sdk/types"
 	"github.com/stretchr/testify/require"
 )
@@ -649,13 +648,13 @@ func TestManagerRegisterHandler(t *testing.T) {
 				name:            "reserved default",
 				typ:             types.ContractTypeDefault,
 				handler:         newFakeHandler(types.ContractTypeDefault),
-				wantErrContains: "already registered",
+				wantErrContains: "reserved by a built-in handler",
 			},
 			{
 				name:            "reserved boarding",
 				typ:             types.ContractTypeBoarding,
 				handler:         newFakeHandler(types.ContractTypeBoarding),
-				wantErrContains: "already registered",
+				wantErrContains: "reserved by a built-in handler",
 			},
 		}
 		for _, f := range fixtures {
@@ -704,35 +703,20 @@ func TestManagerArgsExtraHandlers(t *testing.T) {
 			extras: map[types.ContractType]handlers.Handler{
 				types.ContractTypeDefault: newFakeHandler(types.ContractTypeDefault),
 			},
-			wantErrContains: "already registered",
+			wantErrContains: "reserved by a built-in handler",
 		},
 		{
 			name: "collides with boarding",
 			extras: map[types.ContractType]handlers.Handler{
 				types.ContractTypeBoarding: newFakeHandler(types.ContractTypeBoarding),
 			},
-			wantErrContains: "already registered",
+			wantErrContains: "reserved by a built-in handler",
 		},
 	}
 	for _, f := range fixtures {
 		t.Run(f.name, func(t *testing.T) {
-			env := newMockedEnv(t)
-			svc, err := store.NewStore(store.Config{
-				StoreType: types.SQLStore,
-				Args:      t.TempDir(),
-			})
-			require.NoError(t, err)
-			t.Cleanup(svc.Close)
-
-			_, err = contract.NewManager(contract.Args{
-				Store:         svc.ContractStore(),
-				KeyProvider:   env.identity,
-				Client:        env.transport,
-				Indexer:       env.indexer,
-				Explorer:      env.explorer,
-				Network:       testNetwork,
-				ExtraHandlers: f.extras,
-			})
+			env, cstore := newMockedEnvAndStore(t)
+			_, err := newManagerFromEnv(t, env, cstore, f.extras)
 			require.ErrorContains(t, err, f.wantErrContains)
 		})
 	}

--- a/contract/manager_test.go
+++ b/contract/manager_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/arkade-os/go-sdk/contract"
+	"github.com/arkade-os/go-sdk/contract/handlers"
+	"github.com/arkade-os/go-sdk/store"
 	"github.com/arkade-os/go-sdk/types"
 	"github.com/stretchr/testify/require"
 )
@@ -508,6 +510,232 @@ func TestManagerClean(t *testing.T) {
 		// Cleaning an already-clean store must be a no-op.
 		require.NoError(t, mgr.Clean(t.Context()))
 	})
+}
+
+func TestManagerRegisterHandler(t *testing.T) {
+	const customType = types.ContractType("custom")
+
+	t.Run("valid", func(t *testing.T) {
+		t.Run("runtime registration is visible end-to-end", func(t *testing.T) {
+			mgr, _ := newTestManager(t)
+			require.NoError(
+				t, mgr.RegisterHandler(t.Context(), customType, newFakeHandler(customType)),
+			)
+
+			supported := mgr.GetSupportedContractTypes(t.Context())
+			require.ElementsMatch(t, []types.ContractType{
+				types.ContractTypeDefault, types.ContractTypeBoarding, customType,
+			}, supported)
+
+			c, err := mgr.NewContract(t.Context(), customType)
+			require.NoError(t, err)
+			require.Equal(t, customType, c.Type)
+			require.NotEmpty(t, c.Script)
+
+			h, err := mgr.GetHandler(t.Context(), *c)
+			require.NoError(t, err)
+			require.NotNil(t, h)
+		})
+
+		t.Run("Args.ExtraHandlers wires built-ins and custom together", func(t *testing.T) {
+			_, mgr, _ := newTestManagerWithExtraHandlers(
+				t, map[types.ContractType]handlers.Handler{
+					customType: newFakeHandler(customType),
+				},
+			)
+
+			supported := mgr.GetSupportedContractTypes(t.Context())
+			require.ElementsMatch(t, []types.ContractType{
+				types.ContractTypeDefault, types.ContractTypeBoarding, customType,
+			}, supported)
+
+			// Custom registered at construction.
+			cc, err := mgr.NewContract(t.Context(), customType)
+			require.NoError(t, err)
+			require.Equal(t, customType, cc.Type)
+
+			// Built-in still works alongside.
+			cd, err := mgr.NewContract(t.Context(), types.ContractTypeDefault)
+			require.NoError(t, err)
+			require.Equal(t, types.ContractTypeDefault, cd.Type)
+		})
+
+		t.Run("multiple custom handlers dispatch independently", func(t *testing.T) {
+			// Two distinct custom types registered side by side. Each must
+			// route to its own handler and produce its own script — a bug
+			// where dispatch falls back to a single handler (or where
+			// scripts collide across types) would surface here.
+			const typA = types.ContractType("custom-a")
+			const typB = types.ContractType("custom-b")
+
+			_, mgr, _ := newTestManagerWithExtraHandlers(
+				t, map[types.ContractType]handlers.Handler{
+					typA: newFakeHandler(typA),
+					typB: newFakeHandler(typB),
+				},
+			)
+
+			supported := mgr.GetSupportedContractTypes(t.Context())
+			require.ElementsMatch(t, []types.ContractType{
+				types.ContractTypeDefault, types.ContractTypeBoarding, typA, typB,
+			}, supported)
+
+			ca, err := mgr.NewContract(t.Context(), typA)
+			require.NoError(t, err)
+			require.Equal(t, typA, ca.Type)
+
+			cb, err := mgr.NewContract(t.Context(), typB)
+			require.NoError(t, err)
+			require.Equal(t, typB, cb.Type)
+
+			// fakeScript mixes the type into the digest, so the same key
+			// id under two types must produce different scripts.
+			require.NotEqual(t, ca.Script, cb.Script)
+
+			// GetContracts filtered by each type sees only its own rows.
+			gotA, err := mgr.GetContracts(t.Context(), contract.WithType(typA))
+			require.NoError(t, err)
+			require.Len(t, gotA, 1)
+			require.Equal(t, ca.Script, gotA[0].Script)
+
+			gotB, err := mgr.GetContracts(t.Context(), contract.WithType(typB))
+			require.NoError(t, err)
+			require.Len(t, gotB, 1)
+			require.Equal(t, cb.Script, gotB[0].Script)
+		})
+
+		t.Run("ScanContracts iterates the registered handler", func(t *testing.T) {
+			// Custom-type contracts use the same indexer-backed findUsed path
+			// as offchain default contracts. Staging a script in the indexer
+			// at m/0/2 must persist m/0/0..m/0/2 just like the default case.
+			env, mgr, _ := newTestManagerWithEnv(t)
+			require.NoError(
+				t, mgr.RegisterHandler(t.Context(), customType, newFakeHandler(customType)),
+			)
+			env.indexer.usedScripts = map[string]struct{}{
+				fakeScript(customType, "m/0/2"): {},
+			}
+
+			require.NoError(t, mgr.ScanContracts(t.Context(), 5))
+
+			got, err := mgr.GetContracts(t.Context(), contract.WithType(customType))
+			require.NoError(t, err)
+			require.ElementsMatch(
+				t, []string{"m/0/0", "m/0/1", "m/0/2"}, ownerKeyIds(got),
+			)
+		})
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		fixtures := []struct {
+			name            string
+			typ             types.ContractType
+			handler         handlers.Handler
+			wantErrContains string
+		}{
+			{
+				name:            "empty type",
+				typ:             "",
+				handler:         newFakeHandler(customType),
+				wantErrContains: "missing contract type",
+			},
+			{
+				name:            "nil handler",
+				typ:             customType,
+				handler:         nil,
+				wantErrContains: "nil handler",
+			},
+			{
+				name:            "reserved default",
+				typ:             types.ContractTypeDefault,
+				handler:         newFakeHandler(types.ContractTypeDefault),
+				wantErrContains: "already registered",
+			},
+			{
+				name:            "reserved boarding",
+				typ:             types.ContractTypeBoarding,
+				handler:         newFakeHandler(types.ContractTypeBoarding),
+				wantErrContains: "already registered",
+			},
+		}
+		for _, f := range fixtures {
+			t.Run(f.name, func(t *testing.T) {
+				mgr, _ := newTestManager(t)
+				err := mgr.RegisterHandler(t.Context(), f.typ, f.handler)
+				require.ErrorContains(t, err, f.wantErrContains)
+			})
+		}
+
+		t.Run("duplicate runtime registration", func(t *testing.T) {
+			mgr, _ := newTestManager(t)
+			require.NoError(
+				t, mgr.RegisterHandler(t.Context(), customType, newFakeHandler(customType)),
+			)
+			err := mgr.RegisterHandler(t.Context(), customType, newFakeHandler(customType))
+			require.ErrorContains(t, err, "already registered")
+		})
+	})
+}
+
+func TestManagerArgsExtraHandlers(t *testing.T) {
+	const customType = types.ContractType("custom")
+
+	fixtures := []struct {
+		name            string
+		extras          map[types.ContractType]handlers.Handler
+		wantErrContains string
+	}{
+		{
+			name: "empty type",
+			extras: map[types.ContractType]handlers.Handler{
+				"": newFakeHandler(customType),
+			},
+			wantErrContains: "missing contract type",
+		},
+		{
+			name: "nil handler",
+			extras: map[types.ContractType]handlers.Handler{
+				customType: nil,
+			},
+			wantErrContains: "nil handler",
+		},
+		{
+			name: "collides with default",
+			extras: map[types.ContractType]handlers.Handler{
+				types.ContractTypeDefault: newFakeHandler(types.ContractTypeDefault),
+			},
+			wantErrContains: "already registered",
+		},
+		{
+			name: "collides with boarding",
+			extras: map[types.ContractType]handlers.Handler{
+				types.ContractTypeBoarding: newFakeHandler(types.ContractTypeBoarding),
+			},
+			wantErrContains: "already registered",
+		},
+	}
+	for _, f := range fixtures {
+		t.Run(f.name, func(t *testing.T) {
+			env := newMockedEnv(t)
+			svc, err := store.NewStore(store.Config{
+				StoreType: types.SQLStore,
+				Args:      t.TempDir(),
+			})
+			require.NoError(t, err)
+			t.Cleanup(svc.Close)
+
+			_, err = contract.NewManager(contract.Args{
+				Store:         svc.ContractStore(),
+				KeyProvider:   env.identity,
+				Client:        env.transport,
+				Indexer:       env.indexer,
+				Explorer:      env.explorer,
+				Network:       testNetwork,
+				ExtraHandlers: f.extras,
+			})
+			require.ErrorContains(t, err, f.wantErrContains)
+		})
+	}
 }
 
 func newOffchainContract(t *testing.T, mgr contract.Manager) types.Contract {

--- a/contract/manager_test.go
+++ b/contract/manager_test.go
@@ -645,6 +645,12 @@ func TestManagerRegisterHandler(t *testing.T) {
 				wantErrContains: "nil handler",
 			},
 			{
+				name:            "typed-nil handler",
+				typ:             customType,
+				handler:         (*fakeHandler)(nil),
+				wantErrContains: "nil concrete handler",
+			},
+			{
 				name:            "reserved default",
 				typ:             types.ContractTypeDefault,
 				handler:         newFakeHandler(types.ContractTypeDefault),
@@ -697,6 +703,13 @@ func TestManagerArgsExtraHandlers(t *testing.T) {
 				customType: nil,
 			},
 			wantErrContains: "nil handler",
+		},
+		{
+			name: "typed-nil handler",
+			extras: map[types.ContractType]handlers.Handler{
+				customType: (*fakeHandler)(nil),
+			},
+			wantErrContains: "nil concrete handler",
 		},
 		{
 			name: "collides with default",

--- a/contract/types.go
+++ b/contract/types.go
@@ -34,6 +34,13 @@ type Manager interface {
 	// GetTapscripts, GetExitDelay, …) directly. Errors when the contract type
 	// is not supported.
 	GetHandler(ctx context.Context, contract types.Contract) (handlers.Handler, error)
+	// RegisterHandler registers a handler for a new contract type at runtime.
+	// The type must be non-empty, the handler non-nil, and the type must not
+	// already be registered (built-in types are always registered).
+	// Handlers can also be passed at construction time via Args.ExtraHandlers.
+	RegisterHandler(
+		ctx context.Context, contractType types.ContractType, handler handlers.Handler,
+	) error
 	// Clean removes all contracts from the store. Must be used only at wallet reset.
 	Clean(ctx context.Context) error
 	// Close releases any resources held by the manager.
@@ -48,6 +55,11 @@ type Args struct {
 	Indexer     offchainDataProvider
 	Explorer    onchainDataProvider
 	Network     arklib.Network
+	// ExtraHandlers optionally registers custom contract-type handlers
+	// alongside the built-ins at construction time. The keys must be
+	// non-empty and must not collide with a built-in type. Handlers can
+	// also be added after construction via Manager.RegisterHandler.
+	ExtraHandlers map[types.ContractType]handlers.Handler
 }
 
 // validate ensures the contract manager arguments are valid.

--- a/contract/utils_test.go
+++ b/contract/utils_test.go
@@ -60,17 +60,43 @@ func newTestManagerWithExtraHandlers(
 ) (*mockedEnv, contract.Manager, types.ContractStore) {
 	t.Helper()
 
-	env := newMockedEnv(t)
+	env, store := newMockedEnvAndStore(t)
+	mgr, err := newManagerFromEnv(t, env, store, extras)
+	require.NoError(t, err)
+	t.Cleanup(mgr.Close)
 
+	return env, mgr, store
+}
+
+// newMockedEnvAndStore builds the mocked env plus a fresh SQLite contract
+// store, registering the store for cleanup. Used by helpers that want to
+// keep wiring before NewManager (e.g. tests that expect NewManager itself
+// to fail and so should not require.NoError on it).
+func newMockedEnvAndStore(t *testing.T) (*mockedEnv, types.ContractStore) {
+	t.Helper()
+
+	env := newMockedEnv(t)
 	svc, err := store.NewStore(store.Config{
 		StoreType: types.SQLStore,
 		Args:      t.TempDir(),
 	})
 	require.NoError(t, err)
 	t.Cleanup(svc.Close)
+	return env, svc.ContractStore()
+}
 
-	mgr, err := contract.NewManager(contract.Args{
-		Store:         svc.ContractStore(),
+// newManagerFromEnv constructs a manager against the given env + store,
+// optionally registering extras. Unlike newTestManagerWithExtraHandlers it
+// returns NewManager's error verbatim so failure-path tests can assert on it.
+func newManagerFromEnv(
+	t *testing.T,
+	env *mockedEnv,
+	cstore types.ContractStore,
+	extras map[types.ContractType]handlers.Handler,
+) (contract.Manager, error) {
+	t.Helper()
+	return contract.NewManager(contract.Args{
+		Store:         cstore,
 		KeyProvider:   env.identity,
 		Client:        env.transport,
 		Indexer:       env.indexer,
@@ -78,10 +104,6 @@ func newTestManagerWithExtraHandlers(
 		Network:       testNetwork,
 		ExtraHandlers: extras,
 	})
-	require.NoError(t, err)
-	t.Cleanup(mgr.Close)
-
-	return env, mgr, svc.ContractStore()
 }
 
 func newTestPubKey(t *testing.T) *btcec.PublicKey {

--- a/contract/utils_test.go
+++ b/contract/utils_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/client-lib/indexer"
 	clienttypes "github.com/arkade-os/arkd/pkg/client-lib/types"
 	"github.com/arkade-os/go-sdk/contract"
+	"github.com/arkade-os/go-sdk/contract/handlers"
 	defaultHandler "github.com/arkade-os/go-sdk/contract/handlers/default"
 	hdidentity "github.com/arkade-os/go-sdk/identity"
 	identityinmemorystore "github.com/arkade-os/go-sdk/identity/store/inmemory"
@@ -48,6 +49,16 @@ func newTestManagerWithEnv(
 	t *testing.T,
 ) (*mockedEnv, contract.Manager, types.ContractStore) {
 	t.Helper()
+	return newTestManagerWithExtraHandlers(t, nil)
+}
+
+// newTestManagerWithExtraHandlers wires a manager with the given extra
+// handlers registered at construction time, alongside the env it sits on
+// top of. Pass nil for extras to get the same wiring as newTestManagerWithEnv.
+func newTestManagerWithExtraHandlers(
+	t *testing.T, extras map[types.ContractType]handlers.Handler,
+) (*mockedEnv, contract.Manager, types.ContractStore) {
+	t.Helper()
 
 	env := newMockedEnv(t)
 
@@ -59,12 +70,13 @@ func newTestManagerWithEnv(
 	t.Cleanup(svc.Close)
 
 	mgr, err := contract.NewManager(contract.Args{
-		Store:       svc.ContractStore(),
-		KeyProvider: env.identity,
-		Client:      env.transport,
-		Indexer:     env.indexer,
-		Explorer:    env.explorer,
-		Network:     testNetwork,
+		Store:         svc.ContractStore(),
+		KeyProvider:   env.identity,
+		Client:        env.transport,
+		Indexer:       env.indexer,
+		Explorer:      env.explorer,
+		Network:       testNetwork,
+		ExtraHandlers: extras,
 	})
 	require.NoError(t, err)
 	t.Cleanup(mgr.Close)


### PR DESCRIPTION
closes https://github.com/arkade-os/go-sdk/issues/151

## Summary

Adds a public registration API to `contract.Manager` so callers can plug in handlers for custom contract types alongside the built-in `default` and `boarding` handlers, mirroring the ts-sdk's `ContractHandlerRegistry`.

## API

Two registration paths, both validated through the same helper:

- **At construction**, via `Args.ExtraHandlers map[types.ContractType]handlers.Handler`.
- **At runtime**, via `Manager.RegisterHandler(ctx, contractType, handler) error`.

Validation rejects:
- empty `contractType`
- nil handler (literal nil interface only — a non-nil interface holding a nil concrete pointer will pass; documented on the helper)
- a type reserved by a built-in handler (`default`, `boarding`)
- a type already registered (built-in or prior custom)

The reserved-built-in case returns a distinct error (`"contract type X is reserved by a built-in handler"`) so callers can tell the difference between hitting a reserved name and double-registering a custom one.

## Wiring notes

- `NewManager` wraps `args.Client` with the shared `GetInfo` cache and hands the wrapped client to the built-in handlers only. Caller-supplied handlers were constructed before the manager existed and own their own client wiring — see the extension section of `contract/doc.go`.
- `ScanContracts` iterates all registered handlers. Custom types default to the indexer-backed `findUsedFn` (the same path the offchain default uses). A custom type that needs a different "is this contract used externally" probe is a future extension point.
- Method added to the `Manager` interface — technically a breaking change for any external implementer of `Manager`, but `NewManager` is the only documented constructor.

## Out of scope

- No `Unregister` / `Clear` methods. ts-sdk has them but documents them as test-only; tests here can spin up a fresh `Manager`. Non-breaking to add later.
- No pluggable `findUsedFn` per custom type. Documented as a future extension; not required by #151.
- No port of delegate (#156) or vhtlc (#157) handlers. Those PRs add their built-in registrations directly in `NewManager`; once they land, the reserved-type set picks them up automatically via `builtInContractTypes`.

## Tests

- `TestManagerRegisterHandler`: runtime registration end-to-end (`NewContract` dispatch, `GetHandler` lookup, `GetSupportedContractTypes` inclusion), `Args.ExtraHandlers` wiring, two custom handlers dispatching independently (same key id under two types must produce different scripts), `ScanContracts` iteration of a custom type, and all five rejection paths.
- `TestManagerArgsExtraHandlers`: equivalent rejection paths surfaced at `NewManager` time.
- `contract/fake_handler_test.go`: minimal `handlers.Handler` for tests so the registry tests don't depend on transport-client or network wiring.
- `make lint`: 0 issues. `go test -race ./...`: every in-tree package `ok`; pre-existing `test/e2e` timeout unrelated (requires `make regtest`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom contract handlers can now be registered at initialization time via configuration options or at runtime using a new RegisterHandler method
  * Added validation rules for handler registration to prevent duplicate types and conflicts with built-in handlers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/go-sdk/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->