### PR TITLE
fix: claim keys on identity when contracts are allocated via GetKey

### DIFF
--- a/contract/manager.go
+++ b/contract/manager.go
@@ -117,6 +117,10 @@ func (m *contractManager) NewContract(
 		return nil, fmt.Errorf("failed to store contract: %w", err)
 	}
 
+	if err := m.keyProvider.ClaimKey(ctx, keyRef.Id); err != nil {
+		return nil, fmt.Errorf("failed to claim key on identity: %w", err)
+	}
+
 	log.Debugf("%s added new contract %s", logPrefix, contract.Script)
 
 	return contract, nil
@@ -294,6 +298,15 @@ scan:
 		contract := contractByIndex[i]
 		if err := m.store.AddContract(ctx, contract, i); err != nil {
 			return fmt.Errorf("failed to store %s contract: %w", contractType, err)
+		}
+
+		keyRef, err := handler.GetKeyRef(contract)
+		if err != nil {
+			return fmt.Errorf("failed to get key ref for %s contract: %w", contractType, err)
+		}
+
+		if err := m.keyProvider.ClaimKey(ctx, keyRef.Id); err != nil {
+			return fmt.Errorf("failed to claim key for %s contract: %w", contractType, err)
 		}
 
 		log.Debugf("%s added new %s contract %s", logPrefix, contractType, contract.Script)

--- a/contract/types.go
+++ b/contract/types.go
@@ -81,6 +81,7 @@ type keyProvider interface {
 	GetKeyIndex(ctx context.Context, id string) (uint32, error)
 	NextKeyId(ctx context.Context, id string) (string, error)
 	GetKey(ctx context.Context, id string) (*identity.KeyRef, error)
+	ClaimKey(ctx context.Context, id string) error
 }
 
 type onchainDataProvider interface {

--- a/go.mod
+++ b/go.mod
@@ -110,3 +110,5 @@ require (
 	modernc.org/strutil v1.2.0 // indirect
 	modernc.org/token v1.1.0 // indirect
 )
+
+replace github.com/arkade-os/arkd/pkg/client-lib => github.com/Dunsin-cyber/arkd/pkg/client-lib v0.0.0-20260517192855-a980212cdf0f

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/Dunsin-cyber/arkd/pkg/client-lib v0.0.0-20260517192855-a980212cdf0f h1:hhOCDA/76JHDb+A+PuR4oPbYP8Sc9DmcWNQiHmDP1mg=
+github.com/Dunsin-cyber/arkd/pkg/client-lib v0.0.0-20260517192855-a980212cdf0f/go.mod h1:gSMZ490WXBijQBWUdbaxMKUl7l5sUH0xarOFn6UFqQw=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
@@ -18,8 +20,6 @@ github.com/arkade-os/arkd/api-spec v0.0.0-20260323091657-eeb0baef6937 h1:010LTrh
 github.com/arkade-os/arkd/api-spec v0.0.0-20260323091657-eeb0baef6937/go.mod h1:2+6ix1UGGE22Q/rbab1dycFPPKiTyq0gldKVqVfFPWs=
 github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260429091057-9246f043c4c8 h1:xSPC2XjahDKKMgY1b+Fe3zs16eTkP6BDV6yAKHyjvdc=
 github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260429091057-9246f043c4c8/go.mod h1:gYJkHBV9B9OkSgANCvyST24HTlZ0tSmr1mZSsj+jGAc=
-github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260511114147-89d93031e6ab h1:3tRMQ2oYWtjSZzWL6LM0S3M/brkD4+T6aQcQmVaMzD4=
-github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260511114147-89d93031e6ab/go.mod h1:gSMZ490WXBijQBWUdbaxMKUl7l5sUH0xarOFn6UFqQw=
 github.com/arkade-os/arkd/pkg/errors v0.0.0-20260303153651-8615412e4dea h1:x9ZwZL+F2b9E0uBZYBVjCLGtlqIE4zahDOY4C89h3X4=
 github.com/arkade-os/arkd/pkg/errors v0.0.0-20260303153651-8615412e4dea/go.mod h1:NYGE+baj57ynbXNwjISJddMDpMqAWOX27dV22xqFm2A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -312,6 +312,27 @@ func (s *service) GetKey(_ context.Context, keyId string) (*identity.KeyRef, err
 	return &identity.KeyRef{Id: keyId, PubKey: privKey.PubKey()}, nil
 }
 
+func (s *service) ClaimKey(ctx context.Context, keyId string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.safeCheck(); err != nil {
+		return err
+	}
+	if len(keyId) <= 0 {
+		return fmt.Errorf("key id is required")
+	}
+
+	path, err := parseDerivationIndex(keyId)
+	if err != nil {
+		return fmt.Errorf("failed to parse key id %q: %w", keyId, err)
+	}
+	index := path[len(path)-1]
+
+	s.keyProvider.ClaimIndex(index)
+	return s.persistState(ctx)
+}
+
 func (s *service) ListKeys(_ context.Context) ([]identity.KeyRef, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/identity/key_service.go
+++ b/identity/key_service.go
@@ -77,6 +77,17 @@ func (s *keyService) GetNextKeyIndex() uint32 {
 	return s.nextKeyIndex
 }
 
+// ClaimIndex marks index as allocated, advancing nextKeyIndex past it
+func (s *keyService) ClaimIndex(index uint32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.derivedKeyCache[index] = struct{}{}
+	if index >= s.nextKeyIndex {
+		s.nextKeyIndex = index + 1
+	}
+}
+
 // GetAllKeyRefs returns references for all keys derived with GetNextKey.
 func (s *keyService) GetAllKeyRefs() []identity.KeyRef {
 	s.mu.RLock()

--- a/test/e2e/hd_wallet_test.go
+++ b/test/e2e/hd_wallet_test.go
@@ -54,6 +54,36 @@ func TestHDWalletAddressMethodsAllocateFreshKeys(t *testing.T) {
 	require.Contains(t, onchainAddrs, hdOnchain2)
 }
 
+func TestHDWalletIdentityListKeysReflectsContractKeys(t *testing.T) {
+	ctx := t.Context()
+
+	hdWallet := setupClient(t, "")
+
+	// Fresh wallet: no contracts, no allocated keys.
+	keys, err := hdWallet.Identity().ListKeys(ctx)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+
+	// Allocate 3 offchain addresses and 2 boarding addresses.
+	for range 3 {
+		_, err := hdWallet.NewOffchainAddress(ctx)
+		require.NoError(t, err)
+	}
+	for range 2 {
+		_, err := hdWallet.NewBoardingAddress(ctx)
+		require.NoError(t, err)
+	}
+
+	keys, err = hdWallet.Identity().ListKeys(ctx) 
+	require.NoError(t, err)
+	require.Len(t, keys, 3, "expected 3 distinct keys backing 5 contracts (indices 0,1,2)")
+
+	// Keys must come back sorted by derivation path id ascending.
+	for i := 0; i < len(keys)-1; i++ {
+		require.Less(t, keys[i].Id, keys[i+1].Id, "keys must be sorted by id")
+	}
+}
+
 func TestHDWalletRecoversFundsAtRestore(t *testing.T) {
 	ctx := t.Context()
 


### PR DESCRIPTION
fixes #176

 Draft. Pending before ready for review:
  - [ ] Change the client-lib in go.mod to point to the new release
  - [ ] Test that pins identity.ListKeys returning the right keys after contract allocations
  - [ ] arkade-os/arkd#1067 to merge so ClaimKey lands in a tagged arkd release