### PR TITLE
fix: poll arkd until ready instead of failing on first connection error

### DIFF
--- a/test/docker/setup.go
+++ b/test/docker/setup.go
@@ -34,8 +34,9 @@ func setupArkd() error {
 	}
 
 	fmt.Println("waiting for arkd to be ready...")
-	url := fmt.Sprintf("%s/v1/admin/wallet/status", adminUrl)
-	status, err := getStatusWithRetry(adminHttpClient, url, 30, 2*time.Second)
+	status, err := waitForStatus(adminHttpClient, 30, 2*time.Second, func(*statusResp) bool {
+		return true
+	})
 	if err != nil {
 		return err
 	}
@@ -59,7 +60,7 @@ func setupArkd() error {
 	}
 
 	fmt.Println("getting wallet seed...")
-	url = fmt.Sprintf("%s/v1/admin/wallet/seed", adminUrl)
+	url := fmt.Sprintf("%s/v1/admin/wallet/seed", adminUrl)
 	seed, err := get[seedResp](adminHttpClient, url, "seed")
 	if err != nil {
 		return err
@@ -120,35 +121,34 @@ func get[T any](httpClient *http.Client, url, name string) (*T, error) {
 	return &data, nil
 }
 
-func getStatusWithRetry(
-	httpClient *http.Client, url string, attempts int, interval time.Duration,
+func waitForStatus(
+	httpClient *http.Client, attempts int, interval time.Duration, ready func(*statusResp) bool,
 ) (*statusResp, error) {
+	url := fmt.Sprintf("%s/v1/admin/wallet/status", adminUrl)
 	var lastErr error
 	for i := 1; i <= attempts; i++ {
 		status, err := get[statusResp](httpClient, url, "status")
-		if err == nil {
+		if err != nil {
+			lastErr = err
+			fmt.Printf("arkd not ready yet (attempt %d/%d): %s\n", i, attempts, err)
+		} else if ready(status) {
 			return status, nil
 		}
-		lastErr = err
-		fmt.Printf("arkd not ready yet (attempt %d/%d): %s\n", i, attempts, err)
-		time.Sleep(interval)
+		if i < attempts {
+			time.Sleep(interval)
+		}
 	}
-	return nil, fmt.Errorf("arkd did not become reachable after %d attempts: %s", attempts, lastErr)
+	if lastErr != nil {
+		return nil, fmt.Errorf("arkd did not become ready after %d attempts: %s", attempts, lastErr)
+	}
+	return nil, fmt.Errorf("arkd did not become ready after %d attempts", attempts)
 }
 
 func waitUntilReady(httpClient *http.Client) error {
-	url := fmt.Sprintf("%s/v1/admin/wallet/status", adminUrl)
-	attempts := 30
-	for i := 1; i <= attempts; i++ {
-		status, err := get[statusResp](httpClient, url, "status")
-		if err != nil {
-			fmt.Printf("arkd not reachable yet (attempt %d/%d): %s\n", i, attempts, err)
-		} else if status.Initialized && status.Unlocked && status.Synced {
-			return nil
-		}
-		time.Sleep(2 * time.Second)
-	}
-	return fmt.Errorf("arkd wallet did not become ready after %d attempts", attempts)
+	_, err := waitForStatus(httpClient, 30, 2*time.Second, func(s *statusResp) bool {
+		return s.Initialized && s.Unlocked && s.Synced
+	})
+	return err
 }
 
 func refill(httpClient *http.Client) error {

--- a/test/docker/setup.go
+++ b/test/docker/setup.go
@@ -133,6 +133,11 @@ func waitForStatus(
 			fmt.Printf("arkd not ready yet (attempt %d/%d): %s\n", i, attempts, err)
 		} else if ready(status) {
 			return status, nil
+		} else {
+			fmt.Printf(
+				"arkd reachable but not ready yet (attempt %d/%d): initialized=%v unlocked=%v synced=%v\n",
+				i, attempts, status.Initialized, status.Unlocked, status.Synced,
+			)
 		}
 		if i < attempts {
 			time.Sleep(interval)

--- a/test/docker/setup.go
+++ b/test/docker/setup.go
@@ -33,11 +33,9 @@ func setupArkd() error {
 		Timeout: 15 * time.Second,
 	}
 
-	time.Sleep(3 * time.Second)
-
 	fmt.Println("waiting for arkd to be ready...")
 	url := fmt.Sprintf("%s/v1/admin/wallet/status", adminUrl)
-	status, err := get[statusResp](adminHttpClient, url, "status")
+	status, err := getStatusWithRetry(adminHttpClient, url, 30, 2*time.Second)
 	if err != nil {
 		return err
 	}
@@ -122,21 +120,35 @@ func get[T any](httpClient *http.Client, url, name string) (*T, error) {
 	return &data, nil
 }
 
+func getStatusWithRetry(
+	httpClient *http.Client, url string, attempts int, interval time.Duration,
+) (*statusResp, error) {
+	var lastErr error
+	for i := 1; i <= attempts; i++ {
+		status, err := get[statusResp](httpClient, url, "status")
+		if err == nil {
+			return status, nil
+		}
+		lastErr = err
+		fmt.Printf("arkd not ready yet (attempt %d/%d): %s\n", i, attempts, err)
+		time.Sleep(interval)
+	}
+	return nil, fmt.Errorf("arkd did not become reachable after %d attempts: %s", attempts, lastErr)
+}
+
 func waitUntilReady(httpClient *http.Client) error {
-	ticker := time.NewTicker(2 * time.Second)
 	url := fmt.Sprintf("%s/v1/admin/wallet/status", adminUrl)
-	for range ticker.C {
+	attempts := 30
+	for i := 1; i <= attempts; i++ {
 		status, err := get[statusResp](httpClient, url, "status")
 		if err != nil {
-			return err
+			fmt.Printf("arkd not reachable yet (attempt %d/%d): %s\n", i, attempts, err)
+		} else if status.Initialized && status.Unlocked && status.Synced {
+			return nil
 		}
-
-		if status.Initialized && status.Unlocked && status.Synced {
-			ticker.Stop()
-			break
-		}
+		time.Sleep(2 * time.Second)
 	}
-	return nil
+	return fmt.Errorf("arkd wallet did not become ready after %d attempts", attempts)
 }
 
 func refill(httpClient *http.Client) error {


### PR DESCRIPTION
fixes #188

**before** 
<img width="845" height="143" alt="go-sdk--startupp-err" src="https://github.com/user-attachments/assets/0ccfc031-f27a-4bf0-a8b9-e1030ec01e1a" />

**after**
<img width="729" height="197" alt="go-sdk-startup-err-fixed" src="https://github.com/user-attachments/assets/950264fe-bfb6-4cb3-a448-8c2977353f28" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test setup with improved service readiness verification and error reporting for better reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/go-sdk/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->