### PR TITLE
VHTLC contract handler and standalone vhtlc package

### DIFF
--- a/contract/handlers/default/handler.go
+++ b/contract/handlers/default/handler.go
@@ -53,8 +53,10 @@ func NewHandler(
 	}
 }
 
+func (h *defaultHandler) Derivable() bool { return true }
+
 func (h *defaultHandler) NewContract(
-	ctx context.Context, keyRef identity.KeyRef,
+	ctx context.Context, keyRef identity.KeyRef, _ any,
 ) (*types.Contract, error) {
 	info, err := h.getInfo(ctx)
 	if err != nil {

--- a/contract/handlers/default/handler_test.go
+++ b/contract/handlers/default/handler_test.go
@@ -1,0 +1,616 @@
+package defaultHandler
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"testing"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
+	"github.com/arkade-os/arkd/pkg/client-lib/client"
+	"github.com/arkade-os/arkd/pkg/client-lib/identity"
+	"github.com/arkade-os/go-sdk/contract/handlers"
+	"github.com/arkade-os/go-sdk/types"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	offchainMode = "offchain"
+	onchainMode  = "onchain"
+
+	testUnilateralExitDelay int64 = 144
+	testBoardingExitDelay   int64 = 1024
+
+	testCheckpointTapscript = "03a80040b27520dfcaec558c7e78cf3e38b898ba8a43cfb5727266bae32c5c5b3aeb32c558aa0bac"
+)
+
+var testNetwork = arklib.BitcoinRegTest
+
+type invalidCase struct {
+	name          string
+	params        map[string]string
+	expectedError string
+}
+
+type defaultHandlerMode struct {
+	name            string
+	isOnchain       bool
+	expectType      types.ContractType
+	expectDelay     int64
+	expectDelayType arklib.RelativeLocktimeType
+	expectAddress   string
+}
+
+var defaultHandlerModes = []defaultHandlerMode{
+	{
+		name:            offchainMode,
+		isOnchain:       false,
+		expectType:      types.ContractTypeDefault,
+		expectDelay:     testUnilateralExitDelay,
+		expectDelayType: arklib.LocktimeTypeBlock,
+		expectAddress:   testNetwork.Addr,
+	},
+	{
+		name:            onchainMode,
+		isOnchain:       true,
+		expectType:      types.ContractTypeBoarding,
+		expectDelay:     testBoardingExitDelay,
+		expectDelayType: arklib.LocktimeTypeSecond,
+		expectAddress:   "bcrt1p",
+	},
+}
+
+var defaultInvalidGetKeyRef = []invalidCase{
+	{name: "no params", params: nil, expectedError: "has no parameters"},
+	{
+		name:          "missing key id",
+		params:        map[string]string{ownerKeyParam: "abcd"},
+		expectedError: "missing owner key ID",
+	},
+	{
+		name:          "empty key id",
+		params:        map[string]string{ownerKeyIdParam: "", ownerKeyParam: "abcd"},
+		expectedError: "empty owner key ID",
+	},
+	{
+		name:          "missing owner key",
+		params:        map[string]string{ownerKeyIdParam: "m/0/0"},
+		expectedError: "missing owner key",
+	},
+	{
+		name:          "invalid owner key format",
+		params:        map[string]string{ownerKeyIdParam: "m/0/0", ownerKeyParam: "nothex"},
+		expectedError: "invalid owner key format",
+	},
+	{
+		name: "invalid owner key",
+		params: map[string]string{
+			ownerKeyIdParam: "m/0/0",
+			ownerKeyParam:   hex.EncodeToString([]byte{0x00, 0x01}),
+		},
+		expectedError: "invalid owner key",
+	},
+}
+
+var defaultInvalidGetSignerKey = []invalidCase{
+	{name: "no params", params: nil, expectedError: "has no parameters"},
+	{
+		name:          "missing signer key",
+		params:        map[string]string{ownerKeyIdParam: "m/0/0"},
+		expectedError: "missing signer key",
+	},
+	{
+		name:          "invalid signer key format",
+		params:        map[string]string{signerKeyParam: "nothex"},
+		expectedError: "invalid signer key format",
+	},
+	{
+		name:          "invalid signer key",
+		params:        map[string]string{signerKeyParam: hex.EncodeToString([]byte{0x00, 0x01})},
+		expectedError: "invalid signer key",
+	},
+}
+
+var defaultInvalidGetExitDelay = []invalidCase{
+	{name: "no params", params: nil, expectedError: "has no parameters"},
+	{
+		name:          "missing exit delay",
+		params:        map[string]string{ownerKeyIdParam: "m/0/0"},
+		expectedError: "missing exit delay",
+	},
+	{
+		name:          "invalid exit delay format",
+		params:        map[string]string{exitDelayParam: "notanumber"},
+		expectedError: "invalid exit delay format",
+	},
+}
+
+func TestDefaultHandlerNewContract(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for _, mode := range defaultHandlerModes {
+			t.Run(mode.name, func(t *testing.T) {
+				h := newTestDefaultHandler(t, mode.isOnchain)
+				keyRef := newTestKeyRef(t)
+
+				built, err := h.NewContract(t.Context(), keyRef, nil)
+				require.NoError(t, err)
+				c := *built
+
+				require.Equal(t, mode.expectType, c.Type)
+				require.Equal(t, types.ContractStateActive, c.State)
+				require.NotEmpty(t, c.Script)
+				require.NotEmpty(t, c.Address)
+				require.False(t, c.CreatedAt.IsZero())
+				assertDefaultContract(t, mode, c, keyRef)
+			})
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		for _, mode := range defaultHandlerModes {
+			t.Run(mode.name, func(t *testing.T) {
+				keyRef := newTestKeyRef(t)
+
+				cases := []struct {
+					name          string
+					info          *client.Info
+					infoErr       error
+					expectedError string
+				}{
+					{
+						name:          "GetInfo fails",
+						infoErr:       errors.New("transport error"),
+						expectedError: "failed to get server info",
+					},
+					{
+						name:          "invalid signer pubkey hex",
+						info:          &client.Info{SignerPubKey: "not-hex"},
+						expectedError: "invalid format",
+					},
+					{
+						name: "invalid signer pubkey bytes",
+						info: &client.Info{
+							SignerPubKey: hex.EncodeToString([]byte{0x01, 0x02}),
+						},
+						expectedError: "failed to parse signer pubkey",
+					},
+				}
+
+				for _, c := range cases {
+					t.Run(c.name, func(t *testing.T) {
+						h := NewHandler(
+							&mockClient{info: c.info, infoErr: c.infoErr},
+							testNetwork,
+							mode.isOnchain,
+						)
+						got, err := h.NewContract(t.Context(), keyRef, nil)
+						require.Error(t, err)
+						require.ErrorContains(t, err, c.expectedError)
+						require.Nil(t, got)
+					})
+				}
+			})
+		}
+	})
+}
+
+func TestDefaultHandlerGetKeyRef(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for _, mode := range defaultHandlerModes {
+			t.Run(mode.name, func(t *testing.T) {
+				h, keyRef, c := newDefaultContract(t, mode)
+
+				ref, err := h.GetKeyRef(c)
+				require.NoError(t, err)
+				require.NotNil(t, ref)
+				require.Equal(t, keyRef.Id, ref.Id)
+				require.Equal(
+					t,
+					schnorr.SerializePubKey(keyRef.PubKey),
+					schnorr.SerializePubKey(ref.PubKey),
+				)
+			})
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		for _, mode := range defaultHandlerModes {
+			t.Run(mode.name, func(t *testing.T) {
+				h := newTestDefaultHandler(t, mode.isOnchain)
+				for _, c := range defaultInvalidGetKeyRef {
+					t.Run(c.name, func(t *testing.T) {
+						ref, err := h.GetKeyRef(types.Contract{Script: "broken", Params: c.params})
+						require.Error(t, err)
+						require.ErrorContains(t, err, c.expectedError)
+						require.Nil(t, ref)
+					})
+				}
+			})
+		}
+	})
+}
+
+func TestDefaultHandlerGetKeyRefs(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		t.Run("offchain returns contract and checkpoint scripts", func(t *testing.T) {
+			h, keyRef, c := newDefaultContract(t, defaultHandlerModes[0])
+
+			refs, err := h.GetKeyRefs(c)
+			require.NoError(t, err)
+			require.Len(t, refs, 2)
+			require.Equal(t, keyRef.Id, refs[c.Script])
+			for _, v := range refs {
+				require.Equal(t, keyRef.Id, v)
+			}
+
+			var checkpointScript string
+			for k := range refs {
+				if k != c.Script {
+					checkpointScript = k
+				}
+			}
+			require.NotEmpty(t, checkpointScript)
+			require.NotEqual(t, c.Script, checkpointScript)
+		})
+
+		t.Run("boarding returns only the contract script", func(t *testing.T) {
+			h, keyRef, c := newDefaultContract(t, defaultHandlerModes[1])
+
+			refs, err := h.GetKeyRefs(c)
+			require.NoError(t, err)
+			require.Len(t, refs, 1)
+			require.Equal(t, keyRef.Id, refs[c.Script])
+		})
+
+		t.Run("boarding short-circuits before reading checkpointExitPath", func(t *testing.T) {
+			h, keyRef, c := newDefaultContract(t, defaultHandlerModes[1])
+			delete(c.Params, checkpointExitPathParam)
+
+			refs, err := h.GetKeyRefs(c)
+			require.NoError(t, err)
+			require.Len(t, refs, 1)
+			require.Equal(t, keyRef.Id, refs[c.Script])
+		})
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Run("offchain: getScript failure propagates", func(t *testing.T) {
+			h := newTestDefaultHandler(t, false)
+			refs, err := h.GetKeyRefs(types.Contract{Script: "broken"})
+			require.Error(t, err)
+			require.Nil(t, refs)
+		})
+
+		offchainCases := []struct {
+			name            string
+			mutateContract  func(c *types.Contract)
+			wantErrContains string
+		}{
+			{
+				name: "missing checkpointExitPath",
+				mutateContract: func(c *types.Contract) {
+					delete(c.Params, checkpointExitPathParam)
+				},
+				wantErrContains: "missing checkpoint exit path",
+			},
+			{
+				name: "malformed checkpointExitPath hex",
+				mutateContract: func(c *types.Contract) {
+					c.Params[checkpointExitPathParam] = "nothex"
+				},
+				wantErrContains: "invalid checkpoint exit path format",
+			},
+			{
+				name: "well-formed hex that is not a CSV multisig closure",
+				mutateContract: func(c *types.Contract) {
+					c.Params[checkpointExitPathParam] = hex.EncodeToString([]byte{0x00, 0x01, 0x02})
+				},
+				wantErrContains: "checkpoint exit path",
+			},
+		}
+
+		for _, tc := range offchainCases {
+			t.Run("offchain: "+tc.name, func(t *testing.T) {
+				h, _, c := newDefaultContract(t, defaultHandlerModes[0])
+				tc.mutateContract(&c)
+
+				refs, err := h.GetKeyRefs(c)
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.wantErrContains)
+				require.Nil(t, refs)
+			})
+		}
+	})
+}
+
+func TestDefaultHandlerGetSignerKey(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for _, mode := range defaultHandlerModes {
+			t.Run(mode.name, func(t *testing.T) {
+				h, _, c := newDefaultContract(t, mode)
+
+				signer, err := h.GetSignerKey(c)
+				require.NoError(t, err)
+				require.NotNil(t, signer)
+				assertDefaultSignerKey(t, c, signer)
+			})
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		for _, mode := range defaultHandlerModes {
+			t.Run(mode.name, func(t *testing.T) {
+				h := newTestDefaultHandler(t, mode.isOnchain)
+				for _, c := range defaultInvalidGetSignerKey {
+					t.Run(c.name, func(t *testing.T) {
+						signer, err := h.GetSignerKey(
+							types.Contract{Script: "broken", Params: c.params},
+						)
+						require.Error(t, err)
+						require.ErrorContains(t, err, c.expectedError)
+						require.Nil(t, signer)
+					})
+				}
+			})
+		}
+	})
+}
+
+func TestDefaultHandlerGetExitDelay(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for _, mode := range defaultHandlerModes {
+			t.Run(mode.name, func(t *testing.T) {
+				h, _, c := newDefaultContract(t, mode)
+
+				delay, err := h.GetExitDelay(c)
+				require.NoError(t, err)
+				require.NotNil(t, delay)
+				assertDefaultExitDelay(t, mode, delay)
+			})
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		for _, mode := range defaultHandlerModes {
+			t.Run(mode.name, func(t *testing.T) {
+				h := newTestDefaultHandler(t, mode.isOnchain)
+				for _, c := range defaultInvalidGetExitDelay {
+					t.Run(c.name, func(t *testing.T) {
+						delay, err := h.GetExitDelay(
+							types.Contract{Script: "broken", Params: c.params},
+						)
+						require.Error(t, err)
+						require.ErrorContains(t, err, c.expectedError)
+						require.Nil(t, delay)
+					})
+				}
+			})
+		}
+	})
+}
+
+func TestDefaultHandlerGetTapscripts(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for _, mode := range defaultHandlerModes {
+			t.Run(mode.name, func(t *testing.T) {
+				h, _, c := newDefaultContract(t, mode)
+
+				scripts, err := h.GetTapscripts(c)
+				require.NoError(t, err)
+				require.NotEmpty(t, scripts)
+				for _, s := range scripts {
+					require.NotEmpty(t, s)
+				}
+			})
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		for _, mode := range defaultHandlerModes {
+			t.Run(mode.name, func(t *testing.T) {
+				h := newTestDefaultHandler(t, mode.isOnchain)
+
+				validParams := func() map[string]string {
+					return map[string]string{
+						ownerKeyIdParam: "m/0/0",
+						ownerKeyParam: hex.EncodeToString(
+							schnorr.SerializePubKey(newTestPubKey(t)),
+						),
+						signerKeyParam: hex.EncodeToString(
+							schnorr.SerializePubKey(newTestPubKey(t)),
+						),
+						exitDelayParam: "144",
+					}
+				}
+
+				cases := []struct {
+					name          string
+					mutate        func(map[string]string)
+					expectedError string
+				}{
+					{
+						name:          "missing key ID",
+						mutate:        func(p map[string]string) { delete(p, ownerKeyIdParam) },
+						expectedError: "failed to get key reference",
+					},
+					{
+						name:          "missing signer key",
+						mutate:        func(p map[string]string) { delete(p, signerKeyParam) },
+						expectedError: "failed to get signer key",
+					},
+					{
+						name:          "missing exit delay",
+						mutate:        func(p map[string]string) { delete(p, exitDelayParam) },
+						expectedError: "failed to get exit delay",
+					},
+				}
+
+				for _, c := range cases {
+					t.Run(c.name, func(t *testing.T) {
+						params := validParams()
+						c.mutate(params)
+						scripts, err := h.GetTapscripts(
+							types.Contract{Script: "broken", Params: params},
+						)
+						require.Error(t, err)
+						require.ErrorContains(t, err, c.expectedError)
+						require.Nil(t, scripts)
+					})
+				}
+			})
+		}
+	})
+}
+
+func newTestDefaultHandler(t *testing.T, isOnchain bool) handlers.Handler {
+	t.Helper()
+	info := newTestInfo(newTestPubKey(t))
+	return NewHandler(&mockClient{info: info}, testNetwork, isOnchain)
+}
+
+func newDefaultContract(
+	t *testing.T, mode defaultHandlerMode,
+) (handlers.Handler, identity.KeyRef, types.Contract) {
+	t.Helper()
+	h := newTestDefaultHandler(t, mode.isOnchain)
+	keyRef := newTestKeyRef(t)
+	built, err := h.NewContract(t.Context(), keyRef, nil)
+	require.NoError(t, err)
+	return h, keyRef, *built
+}
+
+func newTestKeyRef(t *testing.T) identity.KeyRef {
+	t.Helper()
+	return identity.KeyRef{Id: "m/0/0", PubKey: newTestPubKey(t)}
+}
+
+func newTestPubKey(t *testing.T) *btcec.PublicKey {
+	t.Helper()
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	return priv.PubKey()
+}
+
+func newTestInfo(signerKey *btcec.PublicKey) *client.Info {
+	return &client.Info{
+		SignerPubKey:        hex.EncodeToString(signerKey.SerializeCompressed()),
+		UnilateralExitDelay: testUnilateralExitDelay,
+		BoardingExitDelay:   testBoardingExitDelay,
+		CheckpointTapscript: testCheckpointTapscript,
+	}
+}
+
+func assertDefaultContract(
+	t *testing.T, mode defaultHandlerMode, c types.Contract, keyRef identity.KeyRef,
+) {
+	t.Helper()
+	require.Equal(t, keyRef.Id, c.Params[ownerKeyIdParam])
+	require.Equal(
+		t,
+		hex.EncodeToString(schnorr.SerializePubKey(keyRef.PubKey)),
+		c.Params[ownerKeyParam],
+	)
+	require.NotEmpty(t, c.Params[signerKeyParam])
+	require.Equal(t, strconv.FormatInt(mode.expectDelay, 10), c.Params[exitDelayParam])
+	require.Contains(t, c.Address, mode.expectAddress)
+}
+
+func assertDefaultSignerKey(t *testing.T, c types.Contract, signer *btcec.PublicKey) {
+	t.Helper()
+	require.Equal(t, c.Params[signerKeyParam], hex.EncodeToString(schnorr.SerializePubKey(signer)))
+}
+
+func assertDefaultExitDelay(
+	t *testing.T, mode defaultHandlerMode, delay *arklib.RelativeLocktime,
+) {
+	t.Helper()
+	require.Equal(t, mode.expectDelayType, delay.Type)
+	require.Equal(t, uint32(mode.expectDelay), delay.Value)
+}
+
+type mockClient struct {
+	info    *client.Info
+	infoErr error
+}
+
+func (f *mockClient) GetInfo(_ context.Context) (*client.Info, error) {
+	return f.info, f.infoErr
+}
+
+func (f *mockClient) RegisterIntent(_ context.Context, _, _ string) (string, error) {
+	return "", nil
+}
+
+func (f *mockClient) DeleteIntent(_ context.Context, _, _ string) error { return nil }
+
+func (f *mockClient) EstimateIntentFee(
+	_ context.Context, _, _ string,
+) (int64, error) {
+	return 0, nil
+}
+
+func (f *mockClient) ConfirmRegistration(_ context.Context, _ string) error { return nil }
+
+func (f *mockClient) SubmitTreeNonces(
+	_ context.Context, _, _ string, _ tree.TreeNonces,
+) error {
+	return nil
+}
+
+func (f *mockClient) SubmitTreeSignatures(
+	_ context.Context, _, _ string, _ tree.TreePartialSigs,
+) error {
+	return nil
+}
+
+func (f *mockClient) SubmitSignedForfeitTxs(
+	_ context.Context, _ []string, _ string,
+) error {
+	return nil
+}
+
+func (f *mockClient) GetEventStream(
+	_ context.Context, _ []string,
+) (<-chan client.BatchEventChannel, func(), error) {
+	return nil, func() {}, nil
+}
+
+func (f *mockClient) SubmitTx(
+	_ context.Context, _ string, _ []string,
+) (string, string, []string, error) {
+	return "", "", nil, nil
+}
+
+func (f *mockClient) FinalizeTx(_ context.Context, _ string, _ []string) error {
+	return nil
+}
+
+func (f *mockClient) GetPendingTx(
+	_ context.Context, _, _ string,
+) ([]client.AcceptedOffchainTx, error) {
+	return nil, nil
+}
+
+func (f *mockClient) GetTransactionsStream(
+	_ context.Context,
+) (<-chan client.TransactionEvent, func(), error) {
+	return nil, func() {}, nil
+}
+
+func (f *mockClient) ModifyStreamTopics(
+	_ context.Context, _, _ []string,
+) ([]string, []string, []string, error) {
+	return nil, nil, nil, nil
+}
+
+func (f *mockClient) OverwriteStreamTopics(
+	_ context.Context, _ []string,
+) ([]string, []string, []string, error) {
+	return nil, nil, nil, nil
+}
+
+func (f *mockClient) Close() {}

--- a/contract/handlers/handler.go
+++ b/contract/handlers/handler.go
@@ -10,7 +10,15 @@ import (
 )
 
 type Handler interface {
-	NewContract(ctx context.Context, keyRef identity.KeyRef) (*types.Contract, error)
+	// Derivable returns whether this handler can derive contracts from an HD key
+	// alone. Derivable handlers participate in ScanContracts gap-limit recovery.
+	// Non-derivable handlers (VHTLC, delegate, covenant) require external params
+	// passed via Manager.NewContract with WithParams.
+	Derivable() bool
+	// NewContract builds a contract from a key reference and optional handler-specific
+	// params. Derivable handlers ignore params (may be nil). Non-derivable handlers
+	// type-assert params to their concrete type (e.g. *VHTLCContractParams).
+	NewContract(ctx context.Context, keyRef identity.KeyRef, params any) (*types.Contract, error)
 	GetKeyRefs(contract types.Contract) (map[string]string, error)
 	GetKeyRef(contract types.Contract) (*identity.KeyRef, error)
 	GetSignerKey(contract types.Contract) (*btcec.PublicKey, error)

--- a/contract/handlers/handler_test.go
+++ b/contract/handlers/handler_test.go
@@ -1,6 +1,8 @@
 package handlers_test
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"strconv"
@@ -11,15 +13,19 @@ import (
 	"github.com/arkade-os/arkd/pkg/client-lib/identity"
 	"github.com/arkade-os/go-sdk/contract/handlers"
 	defaultHandler "github.com/arkade-os/go-sdk/contract/handlers/default"
+	vhtlcHandler "github.com/arkade-os/go-sdk/contract/handlers/vhtlc"
 	"github.com/arkade-os/go-sdk/types"
+	"github.com/arkade-os/go-sdk/vhtlc"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/lightningnetwork/lnd/input"
 	"github.com/stretchr/testify/require"
 )
 
 const (
 	offchainMode = "offchain"
 	onchainMode  = "onchain"
+	vhtlcMode    = "vhtlc"
 
 	// < 512 → block-based RelativeLocktime.
 	testUnilateralExitDelay int64 = 144
@@ -41,28 +47,165 @@ const (
 var testNetwork = arklib.BitcoinRegTest
 
 // modeFixture is one row of the parametrization driving every TestHandler*:
-// each handler kind (offchain default vs onchain boarding) is built once via
-// the factory's isOnchain flag and is expected to produce contracts of the
-// matching type.
+// each handler kind (offchain default, onchain boarding, vhtlc) is built via
+// its handler factory and params factory. The params factory returns the value
+// passed to NewContract (nil for default/boarding, *vhtlc.Opts for vhtlc).
+type invalidCase struct {
+	name          string
+	params        map[string]string
+	expectedError string
+}
+
 type modeFixture struct {
 	name       string
 	isOnchain  bool
 	expectType types.ContractType
+
+	// factories
+	handler func(t *testing.T) handlers.Handler
+	params  func(t *testing.T) any
+
+	// valid-path assertions
+	assertContract  func(t *testing.T, c types.Contract, keyRef identity.KeyRef)
+	assertSignerKey func(t *testing.T, c types.Contract, signer *btcec.PublicKey)
+	assertExitDelay func(t *testing.T, delay *arklib.RelativeLocktime)
+
+	// invalid-path cases per method
+	invalidGetKeyRef    []invalidCase
+	invalidGetSignerKey []invalidCase
+	invalidGetExitDelay []invalidCase
+}
+
+// defaultInvalidGetKeyRef is shared by offchain and onchain default handlers.
+var defaultInvalidGetKeyRef = []invalidCase{
+	{name: "no params", params: nil, expectedError: "has no parameters"},
+	{name: "missing key id", params: map[string]string{ownerKeyParam: "abcd"}, expectedError: "missing owner key ID"},
+	{name: "empty key id", params: map[string]string{ownerKeyIdParam: "", ownerKeyParam: "abcd"}, expectedError: "empty owner key ID"},
+	{name: "missing owner key", params: map[string]string{ownerKeyIdParam: "m/0/0"}, expectedError: "missing owner key"},
+	{name: "invalid owner key format", params: map[string]string{ownerKeyIdParam: "m/0/0", ownerKeyParam: "nothex"}, expectedError: "invalid owner key format"},
+	{name: "invalid owner key", params: map[string]string{ownerKeyIdParam: "m/0/0", ownerKeyParam: hex.EncodeToString([]byte{0x00, 0x01})}, expectedError: "invalid owner key"},
+}
+
+var defaultInvalidGetSignerKey = []invalidCase{
+	{name: "no params", params: nil, expectedError: "has no parameters"},
+	{name: "missing signer key", params: map[string]string{ownerKeyIdParam: "m/0/0"}, expectedError: "missing signer key"},
+	{name: "invalid signer key format", params: map[string]string{signerKeyParam: "nothex"}, expectedError: "invalid signer key format"},
+	{name: "invalid signer key", params: map[string]string{signerKeyParam: hex.EncodeToString([]byte{0x00, 0x01})}, expectedError: "invalid signer key"},
+}
+
+var defaultInvalidGetExitDelay = []invalidCase{
+	{name: "no params", params: nil, expectedError: "has no parameters"},
+	{name: "missing exit delay", params: map[string]string{ownerKeyIdParam: "m/0/0"}, expectedError: "missing exit delay"},
+	{name: "invalid exit delay format", params: map[string]string{exitDelayParam: "notanumber"}, expectedError: "invalid exit delay format"},
+}
+
+func defaultAssertSignerKey(t *testing.T, c types.Contract, signer *btcec.PublicKey) {
+	t.Helper()
+	require.Equal(t, c.Params[signerKeyParam], hex.EncodeToString(schnorr.SerializePubKey(signer)))
 }
 
 var modeFixtures = []modeFixture{
-	{name: offchainMode, isOnchain: false, expectType: types.ContractTypeDefault},
-	{name: onchainMode, isOnchain: true, expectType: types.ContractTypeBoarding},
+	{
+		name: offchainMode, isOnchain: false, expectType: types.ContractTypeDefault,
+		assertContract: func(t *testing.T, c types.Contract, keyRef identity.KeyRef) {
+			t.Helper()
+			require.Equal(t, keyRef.Id, c.Params[ownerKeyIdParam])
+			require.Equal(t, hex.EncodeToString(schnorr.SerializePubKey(keyRef.PubKey)), c.Params[ownerKeyParam])
+			require.NotEmpty(t, c.Params[signerKeyParam])
+			require.Equal(t, strconv.FormatInt(testUnilateralExitDelay, 10), c.Params[exitDelayParam])
+			require.Contains(t, c.Address, testNetwork.Addr)
+		},
+		assertSignerKey: defaultAssertSignerKey,
+		assertExitDelay: func(t *testing.T, delay *arklib.RelativeLocktime) {
+			t.Helper()
+			require.Equal(t, arklib.LocktimeTypeBlock, delay.Type)
+			require.Equal(t, uint32(testUnilateralExitDelay), delay.Value)
+		},
+		invalidGetKeyRef:    defaultInvalidGetKeyRef,
+		invalidGetSignerKey: defaultInvalidGetSignerKey,
+		invalidGetExitDelay: defaultInvalidGetExitDelay,
+	},
+	{
+		name: onchainMode, isOnchain: true, expectType: types.ContractTypeBoarding,
+		assertContract: func(t *testing.T, c types.Contract, keyRef identity.KeyRef) {
+			t.Helper()
+			require.Equal(t, keyRef.Id, c.Params[ownerKeyIdParam])
+			require.Equal(t, hex.EncodeToString(schnorr.SerializePubKey(keyRef.PubKey)), c.Params[ownerKeyParam])
+			require.NotEmpty(t, c.Params[signerKeyParam])
+			require.Equal(t, strconv.FormatInt(testBoardingExitDelay, 10), c.Params[exitDelayParam])
+			require.Contains(t, c.Address, "bcrt1p")
+		},
+		assertSignerKey: defaultAssertSignerKey,
+		assertExitDelay: func(t *testing.T, delay *arklib.RelativeLocktime) {
+			t.Helper()
+			require.Equal(t, arklib.LocktimeTypeSecond, delay.Type)
+			require.Equal(t, uint32(testBoardingExitDelay), delay.Value)
+		},
+		invalidGetKeyRef:    defaultInvalidGetKeyRef,
+		invalidGetSignerKey: defaultInvalidGetSignerKey,
+		invalidGetExitDelay: defaultInvalidGetExitDelay,
+	},
+	{
+		name:       vhtlcMode,
+		expectType: vhtlcHandler.ContractTypeVHTLC,
+		handler: func(t *testing.T) handlers.Handler {
+			t.Helper()
+			return vhtlcHandler.NewHandler(testNetwork)
+		},
+		params: func(t *testing.T) any {
+			t.Helper()
+			return newTestVHTLCOpts(t)
+		},
+		assertContract: func(t *testing.T, c types.Contract, keyRef identity.KeyRef) {
+			t.Helper()
+			require.Equal(t, keyRef.Id, c.Params[ownerKeyIdParam])
+			require.Contains(t, c.Address, testNetwork.Addr)
+		},
+		assertSignerKey: func(t *testing.T, c types.Contract, signer *btcec.PublicKey) {
+			t.Helper()
+			require.Equal(t, c.Params["server"], hex.EncodeToString(signer.SerializeCompressed()))
+		},
+		assertExitDelay: func(t *testing.T, delay *arklib.RelativeLocktime) {
+			t.Helper()
+			require.Equal(t, arklib.LocktimeTypeSecond, delay.Type)
+			require.Equal(t, uint32(1024), delay.Value)
+		},
+		invalidGetKeyRef: []invalidCase{
+			{name: "no params", params: nil, expectedError: "no params"},
+			{name: "missing ownerKeyId", params: map[string]string{"ownerKey": "abcd"}, expectedError: "missing param"},
+			{name: "invalid owner key hex", params: map[string]string{"ownerKeyId": "m/0/0", "ownerKey": "nothex"}, expectedError: "invalid owner key hex"},
+			{name: "invalid owner key", params: map[string]string{"ownerKeyId": "m/0/0", "ownerKey": hex.EncodeToString([]byte{0x00, 0x01})}, expectedError: "invalid owner key"},
+		},
+		invalidGetSignerKey: []invalidCase{
+			{name: "no params", params: nil, expectedError: "no params"},
+			{name: "missing server key", params: map[string]string{"ownerKeyId": "m/0/0"}, expectedError: "missing param"},
+			{name: "invalid server key hex", params: map[string]string{"server": "nothex"}, expectedError: "invalid server hex"},
+			{name: "invalid server key", params: map[string]string{"server": hex.EncodeToString([]byte{0x00, 0x01})}, expectedError: "invalid server"},
+		},
+		invalidGetExitDelay: []invalidCase{
+			{name: "no params", params: nil, expectedError: "no params"},
+			{name: "missing delay type", params: map[string]string{"ownerKeyId": "m/0/0"}, expectedError: "missing param"},
+			{name: "invalid delay value", params: map[string]string{
+				"refundWithoutReceiverDelayType":  "second",
+				"refundWithoutReceiverDelayValue": "notanumber",
+			}, expectedError: "invalid"},
+			{name: "unknown delay type", params: map[string]string{
+				"refundWithoutReceiverDelayType":  "unknown",
+				"refundWithoutReceiverDelayValue": "1024",
+			}, expectedError: "unknown locktime type"},
+		},
+	},
 }
 
 func TestHandlerNewContract(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		for _, mode := range modeFixtures {
 			t.Run(mode.name, func(t *testing.T) {
-				h := newTestHandler(t, mode.isOnchain)
+				h := fixtureHandler(t, mode)
 				keyRef := newTestKeyRef(t)
+				params := fixtureParams(t, mode)
 
-				built, err := h.NewContract(t.Context(), keyRef, nil)
+				built, err := h.NewContract(t.Context(), keyRef, params)
 				require.NoError(t, err)
 				c := *built
 
@@ -71,35 +214,19 @@ func TestHandlerNewContract(t *testing.T) {
 				require.NotEmpty(t, c.Script)
 				require.NotEmpty(t, c.Address)
 				require.False(t, c.CreatedAt.IsZero())
-				require.Equal(t, keyRef.Id, c.Params[ownerKeyIdParam])
-				require.Equal(
-					t,
-					hex.EncodeToString(schnorr.SerializePubKey(keyRef.PubKey)),
-					c.Params[ownerKeyParam],
-				)
-				require.NotEmpty(t, c.Params[signerKeyParam])
 
-				if mode.isOnchain {
-					require.Equal(
-						t,
-						strconv.FormatInt(testBoardingExitDelay, 10),
-						c.Params[exitDelayParam],
-					)
-					require.Contains(t, c.Address, "bcrt1p")
-				} else {
-					require.Equal(
-						t,
-						strconv.FormatInt(testUnilateralExitDelay, 10),
-						c.Params[exitDelayParam],
-					)
-					require.Contains(t, c.Address, testNetwork.Addr)
-				}
+				mode.assertContract(t, c, keyRef)
 			})
 		}
 	})
 
 	t.Run("invalid", func(t *testing.T) {
+		// NewContract invalid tests are specific to the default handler (tests GetInfo errors).
+		// VHTLC NewContract errors (wrong params type) are tested inline below.
 		for _, mode := range modeFixtures {
+			if mode.name == vhtlcMode {
+				continue
+			}
 			t.Run(mode.name, func(t *testing.T) {
 				keyRef := newTestKeyRef(t)
 
@@ -142,6 +269,20 @@ func TestHandlerNewContract(t *testing.T) {
 				}
 			})
 		}
+
+		t.Run("vhtlc: nil params", func(t *testing.T) {
+			h := vhtlcHandler.NewHandler(testNetwork)
+			got, err := h.NewContract(t.Context(), newTestKeyRef(t), nil)
+			require.Error(t, err)
+			require.Nil(t, got)
+		})
+
+		t.Run("vhtlc: wrong params type", func(t *testing.T) {
+			h := vhtlcHandler.NewHandler(testNetwork)
+			got, err := h.NewContract(t.Context(), newTestKeyRef(t), "not-opts")
+			require.Error(t, err)
+			require.Nil(t, got)
+		})
 	})
 }
 
@@ -149,10 +290,10 @@ func TestHandlerGetKeyRef(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		for _, mode := range modeFixtures {
 			t.Run(mode.name, func(t *testing.T) {
-				h := newTestHandler(t, mode.isOnchain)
+				h := fixtureHandler(t, mode)
 				keyRef := newTestKeyRef(t)
 
-				built, err := h.NewContract(t.Context(), keyRef, nil)
+				built, err := h.NewContract(t.Context(), keyRef, fixtureParams(t, mode))
 				require.NoError(t, err)
 				c := *built
 
@@ -174,55 +315,8 @@ func TestHandlerGetKeyRef(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		for _, mode := range modeFixtures {
 			t.Run(mode.name, func(t *testing.T) {
-				h := newTestHandler(t, mode.isOnchain)
-
-				cases := []struct {
-					name          string
-					params        map[string]string
-					expectedError string
-				}{
-					{
-						name:          "no params",
-						params:        nil,
-						expectedError: "has no parameters",
-					},
-					{
-						name:          "missing key id",
-						params:        map[string]string{ownerKeyParam: "abcd"},
-						expectedError: "missing owner key ID",
-					},
-					{
-						name: "empty key id",
-						params: map[string]string{
-							ownerKeyIdParam: "",
-							ownerKeyParam:   "abcd",
-						},
-						expectedError: "empty owner key ID",
-					},
-					{
-						name:          "missing owner key",
-						params:        map[string]string{ownerKeyIdParam: "m/0/0"},
-						expectedError: "missing owner key",
-					},
-					{
-						name: "invalid owner key format",
-						params: map[string]string{
-							ownerKeyIdParam: "m/0/0",
-							ownerKeyParam:   "nothex",
-						},
-						expectedError: "invalid owner key format",
-					},
-					{
-						name: "invalid owner key",
-						params: map[string]string{
-							ownerKeyIdParam: "m/0/0",
-							ownerKeyParam:   hex.EncodeToString([]byte{0x00, 0x01}),
-						},
-						expectedError: "invalid owner key",
-					},
-				}
-
-				for _, c := range cases {
+				h := fixtureHandler(t, mode)
+				for _, c := range mode.invalidGetKeyRef {
 					t.Run(c.name, func(t *testing.T) {
 						ref, err := h.GetKeyRef(types.Contract{Script: "broken", Params: c.params})
 						require.Error(t, err)
@@ -363,21 +457,18 @@ func TestHandlerGetSignerKey(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		for _, mode := range modeFixtures {
 			t.Run(mode.name, func(t *testing.T) {
-				h := newTestHandler(t, mode.isOnchain)
+				h := fixtureHandler(t, mode)
 				keyRef := newTestKeyRef(t)
 
-				built, err := h.NewContract(t.Context(), keyRef, nil)
+				built, err := h.NewContract(t.Context(), keyRef, fixtureParams(t, mode))
 				require.NoError(t, err)
 				c := *built
 
 				signer, err := h.GetSignerKey(c)
 				require.NoError(t, err)
 				require.NotNil(t, signer)
-				require.Equal(
-					t,
-					c.Params[signerKeyParam],
-					hex.EncodeToString(schnorr.SerializePubKey(signer)),
-				)
+
+				mode.assertSignerKey(t, c, signer)
 			})
 		}
 	})
@@ -385,44 +476,10 @@ func TestHandlerGetSignerKey(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		for _, mode := range modeFixtures {
 			t.Run(mode.name, func(t *testing.T) {
-				h := newTestHandler(t, mode.isOnchain)
-
-				cases := []struct {
-					name          string
-					params        map[string]string
-					expectedError string
-				}{
-					{
-						name:          "no params",
-						params:        nil,
-						expectedError: "has no parameters",
-					},
-					{
-						name:          "missing signer key",
-						params:        map[string]string{ownerKeyIdParam: "m/0/0"},
-						expectedError: "missing signer key",
-					},
-					{
-						name: "invalid signer key format",
-						params: map[string]string{
-							signerKeyParam: "nothex",
-						},
-						expectedError: "invalid signer key format",
-					},
-					{
-						name: "invalid signer key",
-						params: map[string]string{
-							signerKeyParam: hex.EncodeToString([]byte{0x00, 0x01}),
-						},
-						expectedError: "invalid signer key",
-					},
-				}
-
-				for _, c := range cases {
+				h := fixtureHandler(t, mode)
+				for _, c := range mode.invalidGetSignerKey {
 					t.Run(c.name, func(t *testing.T) {
-						signer, err := h.GetSignerKey(
-							types.Contract{Script: "broken", Params: c.params},
-						)
+						signer, err := h.GetSignerKey(types.Contract{Script: "broken", Params: c.params})
 						require.Error(t, err)
 						require.ErrorContains(t, err, c.expectedError)
 						require.Nil(t, signer)
@@ -437,10 +494,10 @@ func TestHandlerGetExitDelay(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		for _, mode := range modeFixtures {
 			t.Run(mode.name, func(t *testing.T) {
-				h := newTestHandler(t, mode.isOnchain)
+				h := fixtureHandler(t, mode)
 				keyRef := newTestKeyRef(t)
 
-				built, err := h.NewContract(t.Context(), keyRef, nil)
+				built, err := h.NewContract(t.Context(), keyRef, fixtureParams(t, mode))
 				require.NoError(t, err)
 				c := *built
 
@@ -448,13 +505,7 @@ func TestHandlerGetExitDelay(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, delay)
 
-				if mode.isOnchain {
-					require.Equal(t, arklib.LocktimeTypeSecond, delay.Type)
-					require.Equal(t, uint32(testBoardingExitDelay), delay.Value)
-				} else {
-					require.Equal(t, arklib.LocktimeTypeBlock, delay.Type)
-					require.Equal(t, uint32(testUnilateralExitDelay), delay.Value)
-				}
+				mode.assertExitDelay(t, delay)
 			})
 		}
 	})
@@ -462,37 +513,10 @@ func TestHandlerGetExitDelay(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		for _, mode := range modeFixtures {
 			t.Run(mode.name, func(t *testing.T) {
-				h := newTestHandler(t, mode.isOnchain)
-
-				cases := []struct {
-					name          string
-					params        map[string]string
-					expectedError string
-				}{
-					{
-						name:          "no params",
-						params:        nil,
-						expectedError: "has no parameters",
-					},
-					{
-						name:          "missing exit delay",
-						params:        map[string]string{ownerKeyIdParam: "m/0/0"},
-						expectedError: "missing exit delay",
-					},
-					{
-						name: "invalid exit delay format",
-						params: map[string]string{
-							exitDelayParam: "notanumber",
-						},
-						expectedError: "invalid exit delay format",
-					},
-				}
-
-				for _, c := range cases {
+				h := fixtureHandler(t, mode)
+				for _, c := range mode.invalidGetExitDelay {
 					t.Run(c.name, func(t *testing.T) {
-						delay, err := h.GetExitDelay(
-							types.Contract{Script: "broken", Params: c.params},
-						)
+						delay, err := h.GetExitDelay(types.Contract{Script: "broken", Params: c.params})
 						require.Error(t, err)
 						require.ErrorContains(t, err, c.expectedError)
 						require.Nil(t, delay)
@@ -507,10 +531,10 @@ func TestHandlerGetTapscripts(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		for _, mode := range modeFixtures {
 			t.Run(mode.name, func(t *testing.T) {
-				h := newTestHandler(t, mode.isOnchain)
+				h := fixtureHandler(t, mode)
 				keyRef := newTestKeyRef(t)
 
-				built, err := h.NewContract(t.Context(), keyRef, nil)
+				built, err := h.NewContract(t.Context(), keyRef, fixtureParams(t, mode))
 				require.NoError(t, err)
 				c := *built
 
@@ -525,9 +549,15 @@ func TestHandlerGetTapscripts(t *testing.T) {
 	})
 
 	t.Run("invalid", func(t *testing.T) {
+		// GetTapscripts invalid uses a mutate-params pattern specific to the
+		// default handler. VHTLC error paths are already covered by the
+		// per-method invalid tests above.
 		for _, mode := range modeFixtures {
+			if mode.name == vhtlcMode {
+				continue
+			}
 			t.Run(mode.name, func(t *testing.T) {
-				h := newTestHandler(t, mode.isOnchain)
+				h := fixtureHandler(t, mode)
 
 				// Each case strips a different required param so the corresponding
 				// inner getter (KeyRef / SignerKey / ExitDelay) is the one that fails.
@@ -610,5 +640,51 @@ func newTestInfo(t *testing.T, signerKey *btcec.PublicKey) *client.Info {
 		UnilateralExitDelay: testUnilateralExitDelay,
 		BoardingExitDelay:   testBoardingExitDelay,
 		CheckpointTapscript: testCheckpointTapscript,
+	}
+}
+
+// fixtureHandler returns the handler for a modeFixture, falling back to
+// the default handler factory when the fixture doesn't provide one.
+func fixtureHandler(t *testing.T, mode modeFixture) handlers.Handler {
+	t.Helper()
+	if mode.handler != nil {
+		return mode.handler(t)
+	}
+	return newTestHandler(t, mode.isOnchain)
+}
+
+// fixtureParams returns the params for NewContract, or nil when the
+// fixture doesn't require any.
+func fixtureParams(t *testing.T, mode modeFixture) any {
+	t.Helper()
+	if mode.params != nil {
+		return mode.params(t)
+	}
+	return nil
+}
+
+// newTestVHTLCOpts builds a valid *vhtlc.Opts with random keys for unit tests.
+func newTestVHTLCOpts(t *testing.T) *vhtlc.Opts {
+	t.Helper()
+	preimage := make([]byte, 32)
+	_, err := rand.Read(preimage)
+	require.NoError(t, err)
+	sha256Hash := sha256.Sum256(preimage)
+
+	return &vhtlc.Opts{
+		Sender:         newTestPubKey(t),
+		Receiver:       newTestPubKey(t),
+		Server:         newTestPubKey(t),
+		PreimageHash:   input.Ripemd160H(sha256Hash[:]),
+		RefundLocktime: arklib.AbsoluteLocktime(1577836800), // Jan 1, 2020
+		UnilateralClaimDelay: arklib.RelativeLocktime{
+			Type: arklib.LocktimeTypeSecond, Value: 512,
+		},
+		UnilateralRefundDelay: arklib.RelativeLocktime{
+			Type: arklib.LocktimeTypeSecond, Value: 512,
+		},
+		UnilateralRefundWithoutReceiverDelay: arklib.RelativeLocktime{
+			Type: arklib.LocktimeTypeSecond, Value: 1024,
+		},
 	}
 }

--- a/contract/handlers/handler_test.go
+++ b/contract/handlers/handler_test.go
@@ -4,8 +4,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
-	"strconv"
 	"testing"
 
 	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
@@ -27,685 +25,112 @@ const (
 	onchainMode  = "onchain"
 	vhtlcMode    = "vhtlc"
 
-	// < 512 → block-based RelativeLocktime.
+	// Values below and above 512 exercise block-based and second-based
+	// relative locktime parsing.
 	testUnilateralExitDelay int64 = 144
-	// >= 512 → second-based RelativeLocktime.
-	testBoardingExitDelay int64 = 1024
+	testBoardingExitDelay   int64 = 1024
 
-	// A real CSV-multisig closure encoded as hex — used as the test
-	// checkpoint tapscript whenever an offchain test needs GetKeyRefs to
-	// successfully decode and rebuild the synthetic checkpoint script.
+	// Real CSV-multisig closure encoded as hex. Offchain GetKeyRefs uses this
+	// as the synthetic checkpoint script exit path.
 	testCheckpointTapscript = "03a80040b27520dfcaec558c7e78cf3e38b898ba8a43cfb5727266bae32c5c5b3aeb32c558aa0bac"
-
-	ownerKeyParam           = "ownerKey"
-	ownerKeyIdParam         = "ownerKeyId"
-	signerKeyParam          = "signerKey"
-	exitDelayParam          = "exitDelay"
-	checkpointExitPathParam = "checkpointExitPath"
 )
 
 var testNetwork = arklib.BitcoinRegTest
 
-// modeFixture is one row of the parametrization driving every TestHandler*:
-// each handler kind (offchain default, onchain boarding, vhtlc) is built via
-// its handler factory and params factory. The params factory returns the value
-// passed to NewContract (nil for default/boarding, *vhtlc.Opts for vhtlc).
-type invalidCase struct {
-	name          string
-	params        map[string]string
-	expectedError string
+type handlerInterfaceContractCase struct {
+	name            string
+	handler         func(t *testing.T) handlers.Handler
+	params          func(t *testing.T) any
+	expectType      types.ContractType
+	expectDerivable bool
 }
 
-type modeFixture struct {
-	name       string
-	isOnchain  bool
-	expectType types.ContractType
-
-	// factories
-	handler func(t *testing.T) handlers.Handler
-	params  func(t *testing.T) any
-
-	// valid-path assertions
-	assertContract  func(t *testing.T, c types.Contract, keyRef identity.KeyRef)
-	assertSignerKey func(t *testing.T, c types.Contract, signer *btcec.PublicKey)
-	assertExitDelay func(t *testing.T, delay *arklib.RelativeLocktime)
-
-	// invalid-path cases per method
-	invalidGetKeyRef    []invalidCase
-	invalidGetSignerKey []invalidCase
-	invalidGetExitDelay []invalidCase
-}
-
-// defaultInvalidGetKeyRef is shared by offchain and onchain default handlers.
-var defaultInvalidGetKeyRef = []invalidCase{
-	{name: "no params", params: nil, expectedError: "has no parameters"},
-	{
-		name:          "missing key id",
-		params:        map[string]string{ownerKeyParam: "abcd"},
-		expectedError: "missing owner key ID",
-	},
-	{
-		name:          "empty key id",
-		params:        map[string]string{ownerKeyIdParam: "", ownerKeyParam: "abcd"},
-		expectedError: "empty owner key ID",
-	},
-	{
-		name:          "missing owner key",
-		params:        map[string]string{ownerKeyIdParam: "m/0/0"},
-		expectedError: "missing owner key",
-	},
-	{
-		name:          "invalid owner key format",
-		params:        map[string]string{ownerKeyIdParam: "m/0/0", ownerKeyParam: "nothex"},
-		expectedError: "invalid owner key format",
-	},
-	{
-		name: "invalid owner key",
-		params: map[string]string{
-			ownerKeyIdParam: "m/0/0",
-			ownerKeyParam:   hex.EncodeToString([]byte{0x00, 0x01}),
+func TestHandlerInterfaceContract(t *testing.T) {
+	cases := []handlerInterfaceContractCase{
+		{
+			name:            offchainMode,
+			handler:         func(t *testing.T) handlers.Handler { return newTestDefaultHandler(t, false) },
+			expectType:      types.ContractTypeDefault,
+			expectDerivable: true,
 		},
-		expectedError: "invalid owner key",
-	},
+		{
+			name:            onchainMode,
+			handler:         func(t *testing.T) handlers.Handler { return newTestDefaultHandler(t, true) },
+			expectType:      types.ContractTypeBoarding,
+			expectDerivable: true,
+		},
+		{
+			name: vhtlcMode,
+			handler: func(t *testing.T) handlers.Handler {
+				t.Helper()
+				return vhtlcHandler.NewHandler(testNetwork)
+			},
+			params: func(t *testing.T) any {
+				t.Helper()
+				return newTestVHTLCOpts(t)
+			},
+			expectType:      vhtlcHandler.ContractTypeVHTLC,
+			expectDerivable: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := tc.handler(t)
+			require.Equal(t, tc.expectDerivable, h.Derivable())
+
+			keyRef := newTestKeyRef(t)
+			built, err := h.NewContract(t.Context(), keyRef, testParams(t, tc.params))
+			require.NoError(t, err)
+			c := *built
+
+			require.Equal(t, tc.expectType, c.Type)
+			require.Equal(t, types.ContractStateActive, c.State)
+			require.NotEmpty(t, c.Script)
+			require.NotEmpty(t, c.Address)
+			require.False(t, c.CreatedAt.IsZero())
+
+			ref, err := h.GetKeyRef(c)
+			require.NoError(t, err)
+			require.NotNil(t, ref)
+			require.Equal(t, keyRef.Id, ref.Id)
+			require.Equal(
+				t,
+				schnorr.SerializePubKey(keyRef.PubKey),
+				schnorr.SerializePubKey(ref.PubKey),
+			)
+
+			keyRefs, err := h.GetKeyRefs(c)
+			require.NoError(t, err)
+			require.Equal(t, keyRef.Id, keyRefs[c.Script])
+
+			signer, err := h.GetSignerKey(c)
+			require.NoError(t, err)
+			require.NotNil(t, signer)
+
+			delay, err := h.GetExitDelay(c)
+			require.NoError(t, err)
+			require.NotNil(t, delay)
+			require.NotZero(t, delay.Value)
+
+			scripts, err := h.GetTapscripts(c)
+			require.NoError(t, err)
+			require.NotEmpty(t, scripts)
+		})
+	}
 }
 
-var defaultInvalidGetSignerKey = []invalidCase{
-	{name: "no params", params: nil, expectedError: "has no parameters"},
-	{
-		name:          "missing signer key",
-		params:        map[string]string{ownerKeyIdParam: "m/0/0"},
-		expectedError: "missing signer key",
-	},
-	{
-		name:          "invalid signer key format",
-		params:        map[string]string{signerKeyParam: "nothex"},
-		expectedError: "invalid signer key format",
-	},
-	{
-		name:          "invalid signer key",
-		params:        map[string]string{signerKeyParam: hex.EncodeToString([]byte{0x00, 0x01})},
-		expectedError: "invalid signer key",
-	},
-}
-
-var defaultInvalidGetExitDelay = []invalidCase{
-	{name: "no params", params: nil, expectedError: "has no parameters"},
-	{
-		name:          "missing exit delay",
-		params:        map[string]string{ownerKeyIdParam: "m/0/0"},
-		expectedError: "missing exit delay",
-	},
-	{
-		name:          "invalid exit delay format",
-		params:        map[string]string{exitDelayParam: "notanumber"},
-		expectedError: "invalid exit delay format",
-	},
-}
-
-func defaultAssertSignerKey(t *testing.T, c types.Contract, signer *btcec.PublicKey) {
+func testParams(t *testing.T, params func(t *testing.T) any) any {
 	t.Helper()
-	require.Equal(t, c.Params[signerKeyParam], hex.EncodeToString(schnorr.SerializePubKey(signer)))
+	if params == nil {
+		return nil
+	}
+	return params(t)
 }
 
-var modeFixtures = []modeFixture{
-	{
-		name: offchainMode, isOnchain: false, expectType: types.ContractTypeDefault,
-		assertContract: func(t *testing.T, c types.Contract, keyRef identity.KeyRef) {
-			t.Helper()
-			require.Equal(t, keyRef.Id, c.Params[ownerKeyIdParam])
-			require.Equal(
-				t,
-				hex.EncodeToString(schnorr.SerializePubKey(keyRef.PubKey)),
-				c.Params[ownerKeyParam],
-			)
-			require.NotEmpty(t, c.Params[signerKeyParam])
-			require.Equal(
-				t,
-				strconv.FormatInt(testUnilateralExitDelay, 10),
-				c.Params[exitDelayParam],
-			)
-			require.Contains(t, c.Address, testNetwork.Addr)
-		},
-		assertSignerKey: defaultAssertSignerKey,
-		assertExitDelay: func(t *testing.T, delay *arklib.RelativeLocktime) {
-			t.Helper()
-			require.Equal(t, arklib.LocktimeTypeBlock, delay.Type)
-			require.Equal(t, uint32(testUnilateralExitDelay), delay.Value)
-		},
-		invalidGetKeyRef:    defaultInvalidGetKeyRef,
-		invalidGetSignerKey: defaultInvalidGetSignerKey,
-		invalidGetExitDelay: defaultInvalidGetExitDelay,
-	},
-	{
-		name: onchainMode, isOnchain: true, expectType: types.ContractTypeBoarding,
-		assertContract: func(t *testing.T, c types.Contract, keyRef identity.KeyRef) {
-			t.Helper()
-			require.Equal(t, keyRef.Id, c.Params[ownerKeyIdParam])
-			require.Equal(
-				t,
-				hex.EncodeToString(schnorr.SerializePubKey(keyRef.PubKey)),
-				c.Params[ownerKeyParam],
-			)
-			require.NotEmpty(t, c.Params[signerKeyParam])
-			require.Equal(t, strconv.FormatInt(testBoardingExitDelay, 10), c.Params[exitDelayParam])
-			require.Contains(t, c.Address, "bcrt1p")
-		},
-		assertSignerKey: defaultAssertSignerKey,
-		assertExitDelay: func(t *testing.T, delay *arklib.RelativeLocktime) {
-			t.Helper()
-			require.Equal(t, arklib.LocktimeTypeSecond, delay.Type)
-			require.Equal(t, uint32(testBoardingExitDelay), delay.Value)
-		},
-		invalidGetKeyRef:    defaultInvalidGetKeyRef,
-		invalidGetSignerKey: defaultInvalidGetSignerKey,
-		invalidGetExitDelay: defaultInvalidGetExitDelay,
-	},
-	{
-		name:       vhtlcMode,
-		expectType: vhtlcHandler.ContractTypeVHTLC,
-		handler: func(t *testing.T) handlers.Handler {
-			t.Helper()
-			return vhtlcHandler.NewHandler(testNetwork)
-		},
-		params: func(t *testing.T) any {
-			t.Helper()
-			return newTestVHTLCOpts(t)
-		},
-		assertContract: func(t *testing.T, c types.Contract, keyRef identity.KeyRef) {
-			t.Helper()
-			require.Equal(t, keyRef.Id, c.Params[ownerKeyIdParam])
-			require.Contains(t, c.Address, testNetwork.Addr)
-		},
-		assertSignerKey: func(t *testing.T, c types.Contract, signer *btcec.PublicKey) {
-			t.Helper()
-			require.Equal(t, c.Params["server"], hex.EncodeToString(signer.SerializeCompressed()))
-		},
-		assertExitDelay: func(t *testing.T, delay *arklib.RelativeLocktime) {
-			t.Helper()
-			require.Equal(t, arklib.LocktimeTypeSecond, delay.Type)
-			require.Equal(t, uint32(1024), delay.Value)
-		},
-		invalidGetKeyRef: []invalidCase{
-			{name: "no params", params: nil, expectedError: "no params"},
-			{
-				name:          "missing ownerKeyId",
-				params:        map[string]string{"ownerKey": "abcd"},
-				expectedError: "missing param",
-			},
-			{
-				name:          "invalid owner key hex",
-				params:        map[string]string{"ownerKeyId": "m/0/0", "ownerKey": "nothex"},
-				expectedError: "invalid owner key hex",
-			},
-			{
-				name: "invalid owner key",
-				params: map[string]string{
-					"ownerKeyId": "m/0/0",
-					"ownerKey":   hex.EncodeToString([]byte{0x00, 0x01}),
-				},
-				expectedError: "invalid owner key",
-			},
-		},
-		invalidGetSignerKey: []invalidCase{
-			{name: "no params", params: nil, expectedError: "no params"},
-			{
-				name:          "missing server key",
-				params:        map[string]string{"ownerKeyId": "m/0/0"},
-				expectedError: "missing param",
-			},
-			{
-				name:          "invalid server key hex",
-				params:        map[string]string{"server": "nothex"},
-				expectedError: "invalid server hex",
-			},
-			{
-				name:          "invalid server key",
-				params:        map[string]string{"server": hex.EncodeToString([]byte{0x00, 0x01})},
-				expectedError: "invalid server",
-			},
-		},
-		invalidGetExitDelay: []invalidCase{
-			{name: "no params", params: nil, expectedError: "no params"},
-			{
-				name:          "missing delay type",
-				params:        map[string]string{"ownerKeyId": "m/0/0"},
-				expectedError: "missing param",
-			},
-			{name: "invalid delay value", params: map[string]string{
-				"refundWithoutReceiverDelayType":  "second",
-				"refundWithoutReceiverDelayValue": "notanumber",
-			}, expectedError: "invalid"},
-			{name: "unknown delay type", params: map[string]string{
-				"refundWithoutReceiverDelayType":  "unknown",
-				"refundWithoutReceiverDelayValue": "1024",
-			}, expectedError: "unknown locktime type"},
-		},
-	},
-}
-
-func TestHandlerNewContract(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
-		for _, mode := range modeFixtures {
-			t.Run(mode.name, func(t *testing.T) {
-				h := fixtureHandler(t, mode)
-				keyRef := newTestKeyRef(t)
-				params := fixtureParams(t, mode)
-
-				built, err := h.NewContract(t.Context(), keyRef, params)
-				require.NoError(t, err)
-				c := *built
-
-				require.Equal(t, mode.expectType, c.Type)
-				require.Equal(t, types.ContractStateActive, c.State)
-				require.NotEmpty(t, c.Script)
-				require.NotEmpty(t, c.Address)
-				require.False(t, c.CreatedAt.IsZero())
-
-				mode.assertContract(t, c, keyRef)
-			})
-		}
-	})
-
-	t.Run("invalid", func(t *testing.T) {
-		// NewContract invalid tests are specific to the default handler (tests GetInfo errors).
-		// VHTLC NewContract errors (wrong params type) are tested inline below.
-		for _, mode := range modeFixtures {
-			if mode.name == vhtlcMode {
-				continue
-			}
-			t.Run(mode.name, func(t *testing.T) {
-				keyRef := newTestKeyRef(t)
-
-				cases := []struct {
-					name          string
-					info          *client.Info
-					infoErr       error
-					expectedError string
-				}{
-					{
-						name:          "GetInfo fails",
-						infoErr:       errors.New("transport error"),
-						expectedError: "failed to get server info",
-					},
-					{
-						name:          "invalid signer pubkey hex",
-						info:          &client.Info{SignerPubKey: "not-hex"},
-						expectedError: "invalid format",
-					},
-					{
-						name: "invalid signer pubkey bytes",
-						info: &client.Info{
-							SignerPubKey: hex.EncodeToString([]byte{0x01, 0x02}),
-						},
-						expectedError: "failed to parse signer pubkey",
-					},
-				}
-
-				for _, c := range cases {
-					t.Run(c.name, func(t *testing.T) {
-						h := defaultHandler.NewHandler(
-							&mockClient{info: c.info, infoErr: c.infoErr},
-							testNetwork, mode.isOnchain,
-						)
-						got, err := h.NewContract(t.Context(), keyRef, nil)
-						require.Error(t, err)
-						require.ErrorContains(t, err, c.expectedError)
-						require.Nil(t, got)
-					})
-				}
-			})
-		}
-
-		t.Run("vhtlc: nil params", func(t *testing.T) {
-			h := vhtlcHandler.NewHandler(testNetwork)
-			got, err := h.NewContract(t.Context(), newTestKeyRef(t), nil)
-			require.Error(t, err)
-			require.Nil(t, got)
-		})
-
-		t.Run("vhtlc: wrong params type", func(t *testing.T) {
-			h := vhtlcHandler.NewHandler(testNetwork)
-			got, err := h.NewContract(t.Context(), newTestKeyRef(t), "not-opts")
-			require.Error(t, err)
-			require.Nil(t, got)
-		})
-	})
-}
-
-func TestHandlerGetKeyRef(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
-		for _, mode := range modeFixtures {
-			t.Run(mode.name, func(t *testing.T) {
-				h := fixtureHandler(t, mode)
-				keyRef := newTestKeyRef(t)
-
-				built, err := h.NewContract(t.Context(), keyRef, fixtureParams(t, mode))
-				require.NoError(t, err)
-				c := *built
-
-				ref, err := h.GetKeyRef(c)
-				require.NoError(t, err)
-				require.NotNil(t, ref)
-				require.Equal(t, keyRef.Id, ref.Id)
-				// Schnorr serialization is x-only and drops y-parity, so
-				// compare the canonical encodings, not the parsed *PublicKey.
-				require.Equal(
-					t,
-					schnorr.SerializePubKey(keyRef.PubKey),
-					schnorr.SerializePubKey(ref.PubKey),
-				)
-			})
-		}
-	})
-
-	t.Run("invalid", func(t *testing.T) {
-		for _, mode := range modeFixtures {
-			t.Run(mode.name, func(t *testing.T) {
-				h := fixtureHandler(t, mode)
-				for _, c := range mode.invalidGetKeyRef {
-					t.Run(c.name, func(t *testing.T) {
-						ref, err := h.GetKeyRef(types.Contract{Script: "broken", Params: c.params})
-						require.Error(t, err)
-						require.ErrorContains(t, err, c.expectedError)
-						require.Nil(t, ref)
-					})
-				}
-			})
-		}
-	})
-}
-
-func TestHandlerGetKeyRefs(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
-		t.Run("offchain returns contract and checkpoint scripts", func(t *testing.T) {
-			h := newTestHandler(t, false)
-			keyRef := newTestKeyRef(t)
-
-			built, err := h.NewContract(t.Context(), keyRef, nil)
-			require.NoError(t, err)
-			c := *built
-
-			refs, err := h.GetKeyRefs(c)
-			require.NoError(t, err)
-			// Two entries: the contract's own script and the synthetic
-			// checkpoint script — both must map to the owner key id since
-			// the same wallet key signs in both contexts.
-			require.Len(t, refs, 2)
-			require.Equal(t, keyRef.Id, refs[c.Script])
-			for _, v := range refs {
-				require.Equal(t, keyRef.Id, v)
-			}
-			// The two map keys must be distinct scripts.
-			var checkpointScript string
-			for k := range refs {
-				if k != c.Script {
-					checkpointScript = k
-				}
-			}
-			require.NotEmpty(t, checkpointScript)
-			require.NotEqual(t, c.Script, checkpointScript)
-		})
-
-		t.Run("boarding returns only the contract script", func(t *testing.T) {
-			h := newTestHandler(t, true)
-			keyRef := newTestKeyRef(t)
-
-			built, err := h.NewContract(t.Context(), keyRef, nil)
-			require.NoError(t, err)
-			c := *built
-
-			refs, err := h.GetKeyRefs(c)
-			require.NoError(t, err)
-			require.Len(t, refs, 1)
-			require.Equal(t, keyRef.Id, refs[c.Script])
-		})
-
-		t.Run("boarding short-circuits before reading checkpointExitPath", func(t *testing.T) {
-			// The boarding handler must not consult the checkpoint param
-			// at all — pin this so a refactor that lifts the param read
-			// above the isOnchain branch can't silently break boarding.
-			h := newTestHandler(t, true)
-			keyRef := newTestKeyRef(t)
-
-			built, err := h.NewContract(t.Context(), keyRef, nil)
-			require.NoError(t, err)
-			c := *built
-			delete(c.Params, checkpointExitPathParam)
-
-			refs, err := h.GetKeyRefs(c)
-			require.NoError(t, err)
-			require.Len(t, refs, 1)
-			require.Equal(t, keyRef.Id, refs[c.Script])
-		})
-	})
-
-	t.Run("invalid", func(t *testing.T) {
-		t.Run("offchain: getScript failure propagates", func(t *testing.T) {
-			// Smoke test: the inner GetKeyRef / GetSignerKey / GetExitDelay
-			// failure paths are exhaustively covered by their own tests.
-			// Here we only pin that GetKeyRefs forwards them rather than
-			// silently swallowing.
-			h := newTestHandler(t, false)
-			refs, err := h.GetKeyRefs(types.Contract{Script: "broken"})
-			require.Error(t, err)
-			require.Nil(t, refs)
-		})
-
-		offchainCases := []struct {
-			name            string
-			mutateContract  func(c *types.Contract)
-			wantErrContains string
-		}{
-			{
-				name: "missing checkpointExitPath",
-				mutateContract: func(c *types.Contract) {
-					delete(c.Params, checkpointExitPathParam)
-				},
-				wantErrContains: "missing checkpoint exit path",
-			},
-			{
-				name: "malformed checkpointExitPath hex",
-				mutateContract: func(c *types.Contract) {
-					c.Params[checkpointExitPathParam] = "nothex"
-				},
-				wantErrContains: "invalid checkpoint exit path format",
-			},
-			{
-				name: "well-formed hex that is not a CSV multisig closure",
-				mutateContract: func(c *types.Contract) {
-					c.Params[checkpointExitPathParam] = hex.EncodeToString([]byte{0x00, 0x01, 0x02})
-				},
-				// The closure decoder either errors out or returns
-				// valid=false; both paths surface "checkpoint exit path"
-				// in the wrapped error.
-				wantErrContains: "checkpoint exit path",
-			},
-		}
-
-		for _, tc := range offchainCases {
-			t.Run("offchain: "+tc.name, func(t *testing.T) {
-				h := newTestHandler(t, false)
-				built, err := h.NewContract(t.Context(), newTestKeyRef(t), nil)
-				require.NoError(t, err)
-				c := *built
-				tc.mutateContract(&c)
-
-				refs, err := h.GetKeyRefs(c)
-				require.Error(t, err)
-				require.ErrorContains(t, err, tc.wantErrContains)
-				require.Nil(t, refs)
-			})
-		}
-	})
-}
-
-func TestHandlerGetSignerKey(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
-		for _, mode := range modeFixtures {
-			t.Run(mode.name, func(t *testing.T) {
-				h := fixtureHandler(t, mode)
-				keyRef := newTestKeyRef(t)
-
-				built, err := h.NewContract(t.Context(), keyRef, fixtureParams(t, mode))
-				require.NoError(t, err)
-				c := *built
-
-				signer, err := h.GetSignerKey(c)
-				require.NoError(t, err)
-				require.NotNil(t, signer)
-
-				mode.assertSignerKey(t, c, signer)
-			})
-		}
-	})
-
-	t.Run("invalid", func(t *testing.T) {
-		for _, mode := range modeFixtures {
-			t.Run(mode.name, func(t *testing.T) {
-				h := fixtureHandler(t, mode)
-				for _, c := range mode.invalidGetSignerKey {
-					t.Run(c.name, func(t *testing.T) {
-						signer, err := h.GetSignerKey(
-							types.Contract{Script: "broken", Params: c.params},
-						)
-						require.Error(t, err)
-						require.ErrorContains(t, err, c.expectedError)
-						require.Nil(t, signer)
-					})
-				}
-			})
-		}
-	})
-}
-
-func TestHandlerGetExitDelay(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
-		for _, mode := range modeFixtures {
-			t.Run(mode.name, func(t *testing.T) {
-				h := fixtureHandler(t, mode)
-				keyRef := newTestKeyRef(t)
-
-				built, err := h.NewContract(t.Context(), keyRef, fixtureParams(t, mode))
-				require.NoError(t, err)
-				c := *built
-
-				delay, err := h.GetExitDelay(c)
-				require.NoError(t, err)
-				require.NotNil(t, delay)
-
-				mode.assertExitDelay(t, delay)
-			})
-		}
-	})
-
-	t.Run("invalid", func(t *testing.T) {
-		for _, mode := range modeFixtures {
-			t.Run(mode.name, func(t *testing.T) {
-				h := fixtureHandler(t, mode)
-				for _, c := range mode.invalidGetExitDelay {
-					t.Run(c.name, func(t *testing.T) {
-						delay, err := h.GetExitDelay(
-							types.Contract{Script: "broken", Params: c.params},
-						)
-						require.Error(t, err)
-						require.ErrorContains(t, err, c.expectedError)
-						require.Nil(t, delay)
-					})
-				}
-			})
-		}
-	})
-}
-
-func TestHandlerGetTapscripts(t *testing.T) {
-	t.Run("valid", func(t *testing.T) {
-		for _, mode := range modeFixtures {
-			t.Run(mode.name, func(t *testing.T) {
-				h := fixtureHandler(t, mode)
-				keyRef := newTestKeyRef(t)
-
-				built, err := h.NewContract(t.Context(), keyRef, fixtureParams(t, mode))
-				require.NoError(t, err)
-				c := *built
-
-				scripts, err := h.GetTapscripts(c)
-				require.NoError(t, err)
-				require.NotEmpty(t, scripts)
-				for _, s := range scripts {
-					require.NotEmpty(t, s)
-				}
-			})
-		}
-	})
-
-	t.Run("invalid", func(t *testing.T) {
-		// GetTapscripts invalid uses a mutate-params pattern specific to the
-		// default handler. VHTLC error paths are already covered by the
-		// per-method invalid tests above.
-		for _, mode := range modeFixtures {
-			if mode.name == vhtlcMode {
-				continue
-			}
-			t.Run(mode.name, func(t *testing.T) {
-				h := fixtureHandler(t, mode)
-
-				// Each case strips a different required param so the corresponding
-				// inner getter (KeyRef / SignerKey / ExitDelay) is the one that fails.
-				validParams := func() map[string]string {
-					return map[string]string{
-						ownerKeyIdParam: "m/0/0",
-						ownerKeyParam: hex.EncodeToString(
-							schnorr.SerializePubKey(newTestPubKey(t)),
-						),
-						signerKeyParam: hex.EncodeToString(
-							schnorr.SerializePubKey(newTestPubKey(t)),
-						),
-						exitDelayParam: "144",
-					}
-				}
-
-				cases := []struct {
-					name          string
-					mutate        func(map[string]string)
-					expectedError string
-				}{
-					{
-						name:          "missing key ID",
-						mutate:        func(p map[string]string) { delete(p, ownerKeyIdParam) },
-						expectedError: "failed to get key reference",
-					},
-					{
-						name:          "missing signer key",
-						mutate:        func(p map[string]string) { delete(p, signerKeyParam) },
-						expectedError: "failed to get signer key",
-					},
-					{
-						name:          "missing exit delay",
-						mutate:        func(p map[string]string) { delete(p, exitDelayParam) },
-						expectedError: "failed to get exit delay",
-					},
-				}
-
-				for _, c := range cases {
-					t.Run(c.name, func(t *testing.T) {
-						params := validParams()
-						c.mutate(params)
-						scripts, err := h.GetTapscripts(
-							types.Contract{Script: "broken", Params: params},
-						)
-						require.Error(t, err)
-						require.ErrorContains(t, err, c.expectedError)
-						require.Nil(t, scripts)
-					})
-				}
-			})
-		}
-	})
-}
-
-func newTestHandler(t *testing.T, isOnchain bool) handlers.Handler {
+func newTestDefaultHandler(t *testing.T, isOnchain bool) handlers.Handler {
 	t.Helper()
-	info := newTestInfo(t, newTestPubKey(t))
+	info := newTestInfo(newTestPubKey(t))
 	return defaultHandler.NewHandler(
 		&mockClient{info: info}, testNetwork, isOnchain,
 	)
@@ -723,8 +148,7 @@ func newTestPubKey(t *testing.T) *btcec.PublicKey {
 	return priv.PubKey()
 }
 
-func newTestInfo(t *testing.T, signerKey *btcec.PublicKey) *client.Info {
-	t.Helper()
+func newTestInfo(signerKey *btcec.PublicKey) *client.Info {
 	return &client.Info{
 		SignerPubKey:        hex.EncodeToString(signerKey.SerializeCompressed()),
 		UnilateralExitDelay: testUnilateralExitDelay,
@@ -733,27 +157,6 @@ func newTestInfo(t *testing.T, signerKey *btcec.PublicKey) *client.Info {
 	}
 }
 
-// fixtureHandler returns the handler for a modeFixture, falling back to
-// the default handler factory when the fixture doesn't provide one.
-func fixtureHandler(t *testing.T, mode modeFixture) handlers.Handler {
-	t.Helper()
-	if mode.handler != nil {
-		return mode.handler(t)
-	}
-	return newTestHandler(t, mode.isOnchain)
-}
-
-// fixtureParams returns the params for NewContract, or nil when the
-// fixture doesn't require any.
-func fixtureParams(t *testing.T, mode modeFixture) any {
-	t.Helper()
-	if mode.params != nil {
-		return mode.params(t)
-	}
-	return nil
-}
-
-// newTestVHTLCOpts builds a valid *vhtlc.Opts with random keys for unit tests.
 func newTestVHTLCOpts(t *testing.T) *vhtlc.Opts {
 	t.Helper()
 	preimage := make([]byte, 32)
@@ -766,7 +169,7 @@ func newTestVHTLCOpts(t *testing.T) *vhtlc.Opts {
 		Receiver:       newTestPubKey(t),
 		Server:         newTestPubKey(t),
 		PreimageHash:   input.Ripemd160H(sha256Hash[:]),
-		RefundLocktime: arklib.AbsoluteLocktime(1577836800), // Jan 1, 2020
+		RefundLocktime: arklib.AbsoluteLocktime(1577836800),
 		UnilateralClaimDelay: arklib.RelativeLocktime{
 			Type: arklib.LocktimeTypeSecond, Value: 512,
 		},

--- a/contract/handlers/handler_test.go
+++ b/contract/handlers/handler_test.go
@@ -62,7 +62,7 @@ func TestHandlerNewContract(t *testing.T) {
 				h := newTestHandler(t, mode.isOnchain)
 				keyRef := newTestKeyRef(t)
 
-				built, err := h.NewContract(t.Context(), keyRef)
+				built, err := h.NewContract(t.Context(), keyRef, nil)
 				require.NoError(t, err)
 				c := *built
 
@@ -134,7 +134,7 @@ func TestHandlerNewContract(t *testing.T) {
 							&mockClient{info: c.info, infoErr: c.infoErr},
 							testNetwork, mode.isOnchain,
 						)
-						got, err := h.NewContract(t.Context(), keyRef)
+						got, err := h.NewContract(t.Context(), keyRef, nil)
 						require.Error(t, err)
 						require.ErrorContains(t, err, c.expectedError)
 						require.Nil(t, got)
@@ -152,7 +152,7 @@ func TestHandlerGetKeyRef(t *testing.T) {
 				h := newTestHandler(t, mode.isOnchain)
 				keyRef := newTestKeyRef(t)
 
-				built, err := h.NewContract(t.Context(), keyRef)
+				built, err := h.NewContract(t.Context(), keyRef, nil)
 				require.NoError(t, err)
 				c := *built
 
@@ -241,7 +241,7 @@ func TestHandlerGetKeyRefs(t *testing.T) {
 			h := newTestHandler(t, false)
 			keyRef := newTestKeyRef(t)
 
-			built, err := h.NewContract(t.Context(), keyRef)
+			built, err := h.NewContract(t.Context(), keyRef, nil)
 			require.NoError(t, err)
 			c := *built
 
@@ -270,7 +270,7 @@ func TestHandlerGetKeyRefs(t *testing.T) {
 			h := newTestHandler(t, true)
 			keyRef := newTestKeyRef(t)
 
-			built, err := h.NewContract(t.Context(), keyRef)
+			built, err := h.NewContract(t.Context(), keyRef, nil)
 			require.NoError(t, err)
 			c := *built
 
@@ -287,7 +287,7 @@ func TestHandlerGetKeyRefs(t *testing.T) {
 			h := newTestHandler(t, true)
 			keyRef := newTestKeyRef(t)
 
-			built, err := h.NewContract(t.Context(), keyRef)
+			built, err := h.NewContract(t.Context(), keyRef, nil)
 			require.NoError(t, err)
 			c := *built
 			delete(c.Params, checkpointExitPathParam)
@@ -345,7 +345,7 @@ func TestHandlerGetKeyRefs(t *testing.T) {
 		for _, tc := range offchainCases {
 			t.Run("offchain: "+tc.name, func(t *testing.T) {
 				h := newTestHandler(t, false)
-				built, err := h.NewContract(t.Context(), newTestKeyRef(t))
+				built, err := h.NewContract(t.Context(), newTestKeyRef(t), nil)
 				require.NoError(t, err)
 				c := *built
 				tc.mutateContract(&c)
@@ -366,7 +366,7 @@ func TestHandlerGetSignerKey(t *testing.T) {
 				h := newTestHandler(t, mode.isOnchain)
 				keyRef := newTestKeyRef(t)
 
-				built, err := h.NewContract(t.Context(), keyRef)
+				built, err := h.NewContract(t.Context(), keyRef, nil)
 				require.NoError(t, err)
 				c := *built
 
@@ -440,7 +440,7 @@ func TestHandlerGetExitDelay(t *testing.T) {
 				h := newTestHandler(t, mode.isOnchain)
 				keyRef := newTestKeyRef(t)
 
-				built, err := h.NewContract(t.Context(), keyRef)
+				built, err := h.NewContract(t.Context(), keyRef, nil)
 				require.NoError(t, err)
 				c := *built
 
@@ -510,7 +510,7 @@ func TestHandlerGetTapscripts(t *testing.T) {
 				h := newTestHandler(t, mode.isOnchain)
 				keyRef := newTestKeyRef(t)
 
-				built, err := h.NewContract(t.Context(), keyRef)
+				built, err := h.NewContract(t.Context(), keyRef, nil)
 				require.NoError(t, err)
 				c := *built
 

--- a/contract/handlers/handler_test.go
+++ b/contract/handlers/handler_test.go
@@ -79,24 +79,67 @@ type modeFixture struct {
 // defaultInvalidGetKeyRef is shared by offchain and onchain default handlers.
 var defaultInvalidGetKeyRef = []invalidCase{
 	{name: "no params", params: nil, expectedError: "has no parameters"},
-	{name: "missing key id", params: map[string]string{ownerKeyParam: "abcd"}, expectedError: "missing owner key ID"},
-	{name: "empty key id", params: map[string]string{ownerKeyIdParam: "", ownerKeyParam: "abcd"}, expectedError: "empty owner key ID"},
-	{name: "missing owner key", params: map[string]string{ownerKeyIdParam: "m/0/0"}, expectedError: "missing owner key"},
-	{name: "invalid owner key format", params: map[string]string{ownerKeyIdParam: "m/0/0", ownerKeyParam: "nothex"}, expectedError: "invalid owner key format"},
-	{name: "invalid owner key", params: map[string]string{ownerKeyIdParam: "m/0/0", ownerKeyParam: hex.EncodeToString([]byte{0x00, 0x01})}, expectedError: "invalid owner key"},
+	{
+		name:          "missing key id",
+		params:        map[string]string{ownerKeyParam: "abcd"},
+		expectedError: "missing owner key ID",
+	},
+	{
+		name:          "empty key id",
+		params:        map[string]string{ownerKeyIdParam: "", ownerKeyParam: "abcd"},
+		expectedError: "empty owner key ID",
+	},
+	{
+		name:          "missing owner key",
+		params:        map[string]string{ownerKeyIdParam: "m/0/0"},
+		expectedError: "missing owner key",
+	},
+	{
+		name:          "invalid owner key format",
+		params:        map[string]string{ownerKeyIdParam: "m/0/0", ownerKeyParam: "nothex"},
+		expectedError: "invalid owner key format",
+	},
+	{
+		name: "invalid owner key",
+		params: map[string]string{
+			ownerKeyIdParam: "m/0/0",
+			ownerKeyParam:   hex.EncodeToString([]byte{0x00, 0x01}),
+		},
+		expectedError: "invalid owner key",
+	},
 }
 
 var defaultInvalidGetSignerKey = []invalidCase{
 	{name: "no params", params: nil, expectedError: "has no parameters"},
-	{name: "missing signer key", params: map[string]string{ownerKeyIdParam: "m/0/0"}, expectedError: "missing signer key"},
-	{name: "invalid signer key format", params: map[string]string{signerKeyParam: "nothex"}, expectedError: "invalid signer key format"},
-	{name: "invalid signer key", params: map[string]string{signerKeyParam: hex.EncodeToString([]byte{0x00, 0x01})}, expectedError: "invalid signer key"},
+	{
+		name:          "missing signer key",
+		params:        map[string]string{ownerKeyIdParam: "m/0/0"},
+		expectedError: "missing signer key",
+	},
+	{
+		name:          "invalid signer key format",
+		params:        map[string]string{signerKeyParam: "nothex"},
+		expectedError: "invalid signer key format",
+	},
+	{
+		name:          "invalid signer key",
+		params:        map[string]string{signerKeyParam: hex.EncodeToString([]byte{0x00, 0x01})},
+		expectedError: "invalid signer key",
+	},
 }
 
 var defaultInvalidGetExitDelay = []invalidCase{
 	{name: "no params", params: nil, expectedError: "has no parameters"},
-	{name: "missing exit delay", params: map[string]string{ownerKeyIdParam: "m/0/0"}, expectedError: "missing exit delay"},
-	{name: "invalid exit delay format", params: map[string]string{exitDelayParam: "notanumber"}, expectedError: "invalid exit delay format"},
+	{
+		name:          "missing exit delay",
+		params:        map[string]string{ownerKeyIdParam: "m/0/0"},
+		expectedError: "missing exit delay",
+	},
+	{
+		name:          "invalid exit delay format",
+		params:        map[string]string{exitDelayParam: "notanumber"},
+		expectedError: "invalid exit delay format",
+	},
 }
 
 func defaultAssertSignerKey(t *testing.T, c types.Contract, signer *btcec.PublicKey) {
@@ -110,9 +153,17 @@ var modeFixtures = []modeFixture{
 		assertContract: func(t *testing.T, c types.Contract, keyRef identity.KeyRef) {
 			t.Helper()
 			require.Equal(t, keyRef.Id, c.Params[ownerKeyIdParam])
-			require.Equal(t, hex.EncodeToString(schnorr.SerializePubKey(keyRef.PubKey)), c.Params[ownerKeyParam])
+			require.Equal(
+				t,
+				hex.EncodeToString(schnorr.SerializePubKey(keyRef.PubKey)),
+				c.Params[ownerKeyParam],
+			)
 			require.NotEmpty(t, c.Params[signerKeyParam])
-			require.Equal(t, strconv.FormatInt(testUnilateralExitDelay, 10), c.Params[exitDelayParam])
+			require.Equal(
+				t,
+				strconv.FormatInt(testUnilateralExitDelay, 10),
+				c.Params[exitDelayParam],
+			)
 			require.Contains(t, c.Address, testNetwork.Addr)
 		},
 		assertSignerKey: defaultAssertSignerKey,
@@ -130,7 +181,11 @@ var modeFixtures = []modeFixture{
 		assertContract: func(t *testing.T, c types.Contract, keyRef identity.KeyRef) {
 			t.Helper()
 			require.Equal(t, keyRef.Id, c.Params[ownerKeyIdParam])
-			require.Equal(t, hex.EncodeToString(schnorr.SerializePubKey(keyRef.PubKey)), c.Params[ownerKeyParam])
+			require.Equal(
+				t,
+				hex.EncodeToString(schnorr.SerializePubKey(keyRef.PubKey)),
+				c.Params[ownerKeyParam],
+			)
 			require.NotEmpty(t, c.Params[signerKeyParam])
 			require.Equal(t, strconv.FormatInt(testBoardingExitDelay, 10), c.Params[exitDelayParam])
 			require.Contains(t, c.Address, "bcrt1p")
@@ -172,19 +227,50 @@ var modeFixtures = []modeFixture{
 		},
 		invalidGetKeyRef: []invalidCase{
 			{name: "no params", params: nil, expectedError: "no params"},
-			{name: "missing ownerKeyId", params: map[string]string{"ownerKey": "abcd"}, expectedError: "missing param"},
-			{name: "invalid owner key hex", params: map[string]string{"ownerKeyId": "m/0/0", "ownerKey": "nothex"}, expectedError: "invalid owner key hex"},
-			{name: "invalid owner key", params: map[string]string{"ownerKeyId": "m/0/0", "ownerKey": hex.EncodeToString([]byte{0x00, 0x01})}, expectedError: "invalid owner key"},
+			{
+				name:          "missing ownerKeyId",
+				params:        map[string]string{"ownerKey": "abcd"},
+				expectedError: "missing param",
+			},
+			{
+				name:          "invalid owner key hex",
+				params:        map[string]string{"ownerKeyId": "m/0/0", "ownerKey": "nothex"},
+				expectedError: "invalid owner key hex",
+			},
+			{
+				name: "invalid owner key",
+				params: map[string]string{
+					"ownerKeyId": "m/0/0",
+					"ownerKey":   hex.EncodeToString([]byte{0x00, 0x01}),
+				},
+				expectedError: "invalid owner key",
+			},
 		},
 		invalidGetSignerKey: []invalidCase{
 			{name: "no params", params: nil, expectedError: "no params"},
-			{name: "missing server key", params: map[string]string{"ownerKeyId": "m/0/0"}, expectedError: "missing param"},
-			{name: "invalid server key hex", params: map[string]string{"server": "nothex"}, expectedError: "invalid server hex"},
-			{name: "invalid server key", params: map[string]string{"server": hex.EncodeToString([]byte{0x00, 0x01})}, expectedError: "invalid server"},
+			{
+				name:          "missing server key",
+				params:        map[string]string{"ownerKeyId": "m/0/0"},
+				expectedError: "missing param",
+			},
+			{
+				name:          "invalid server key hex",
+				params:        map[string]string{"server": "nothex"},
+				expectedError: "invalid server hex",
+			},
+			{
+				name:          "invalid server key",
+				params:        map[string]string{"server": hex.EncodeToString([]byte{0x00, 0x01})},
+				expectedError: "invalid server",
+			},
 		},
 		invalidGetExitDelay: []invalidCase{
 			{name: "no params", params: nil, expectedError: "no params"},
-			{name: "missing delay type", params: map[string]string{"ownerKeyId": "m/0/0"}, expectedError: "missing param"},
+			{
+				name:          "missing delay type",
+				params:        map[string]string{"ownerKeyId": "m/0/0"},
+				expectedError: "missing param",
+			},
 			{name: "invalid delay value", params: map[string]string{
 				"refundWithoutReceiverDelayType":  "second",
 				"refundWithoutReceiverDelayValue": "notanumber",
@@ -479,7 +565,9 @@ func TestHandlerGetSignerKey(t *testing.T) {
 				h := fixtureHandler(t, mode)
 				for _, c := range mode.invalidGetSignerKey {
 					t.Run(c.name, func(t *testing.T) {
-						signer, err := h.GetSignerKey(types.Contract{Script: "broken", Params: c.params})
+						signer, err := h.GetSignerKey(
+							types.Contract{Script: "broken", Params: c.params},
+						)
 						require.Error(t, err)
 						require.ErrorContains(t, err, c.expectedError)
 						require.Nil(t, signer)
@@ -516,7 +604,9 @@ func TestHandlerGetExitDelay(t *testing.T) {
 				h := fixtureHandler(t, mode)
 				for _, c := range mode.invalidGetExitDelay {
 					t.Run(c.name, func(t *testing.T) {
-						delay, err := h.GetExitDelay(types.Contract{Script: "broken", Params: c.params})
+						delay, err := h.GetExitDelay(
+							types.Contract{Script: "broken", Params: c.params},
+						)
 						require.Error(t, err)
 						require.ErrorContains(t, err, c.expectedError)
 						require.Nil(t, delay)

--- a/contract/handlers/vhtlc/handler.go
+++ b/contract/handlers/vhtlc/handler.go
@@ -71,7 +71,9 @@ func (h *Handler) NewContract(
 ) (*types.Contract, error) {
 	p, ok := params.(*vhtlc.Opts)
 	if !ok || p == nil {
-		return nil, fmt.Errorf("vhtlc handler requires *vhtlcHandler.ContractParams, got %T", params)
+		return nil, fmt.Errorf(
+			"vhtlc handler requires *vhtlc.Opts, got %T", params,
+		)
 	}
 	return createContract(*p, keyRef, h.network)
 }

--- a/contract/handlers/vhtlc/handler.go
+++ b/contract/handlers/vhtlc/handler.go
@@ -1,0 +1,342 @@
+package vhtlcHandler
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"time"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/client-lib/identity"
+	"github.com/arkade-os/go-sdk/contract/handlers"
+	"github.com/arkade-os/go-sdk/types"
+	"github.com/arkade-os/go-sdk/vhtlc"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+)
+
+// ContractTypeVHTLC is the contract type for VHTLC contracts.
+const ContractTypeVHTLC types.ContractType = "vhtlc"
+
+// Param keys stored in Contract.Params.
+const (
+	paramOwnerKeyID                      = "ownerKeyId"
+	paramOwnerKey                        = "ownerKey"
+	paramSender                          = "sender"
+	paramReceiver                        = "receiver"
+	paramServer                          = "server"
+	paramPreimageHash                    = "preimageHash"
+	paramRefundLocktime                  = "refundLocktime"
+	paramClaimDelayType                  = "claimDelayType"
+	paramClaimDelayValue                 = "claimDelayValue"
+	paramRefundDelayType                 = "refundDelayType"
+	paramRefundDelayValue                = "refundDelayValue"
+	paramRefundWithoutReceiverDelayType  = "refundWithoutReceiverDelayType"
+	paramRefundWithoutReceiverDelayValue = "refundWithoutReceiverDelayValue"
+	paramNICReceiverPkScript             = "nicReceiverPkScript"
+	paramNICIntrospectorPubKey           = "nicIntrospectorPubKey"
+)
+
+const (
+	locktimeTagBlock  = "block"
+	locktimeTagSecond = "second"
+)
+
+// Handler is a stateless contract handler for VHTLC scripts.
+// All VHTLC parameters are stored in Contract.Params, so the handler
+// can rebuild the full tapscript tree from any persisted contract.
+type Handler struct{}
+
+// NewHandler returns a VHTLC contract handler ready to be registered via
+// WithContractHandler(ContractTypeVHTLC, vhtlcHandler.NewHandler()).
+func NewHandler() *Handler { return &Handler{} }
+
+// Derivable returns false — VHTLC contracts require counterparty data
+// (pubkeys, preimage hash, locktimes) and cannot be derived from an HD key alone.
+// Callers must provide WithParams(*ContractParams) when calling Manager.NewContract.
+func (h *Handler) Derivable() bool { return false }
+
+// ContractParams contains the handler-specific parameters for creating a VHTLC
+// contract. Pass via contract.WithParams(&vhtlcHandler.ContractParams{...}).
+type ContractParams struct {
+	Opts    vhtlc.Opts
+	Network arklib.Network
+}
+
+// NewContract builds a VHTLC contract from the caller-provided key and params.
+// params must be *ContractParams; returns an error otherwise.
+func (h *Handler) NewContract(
+	_ context.Context, keyRef identity.KeyRef, params any,
+) (*types.Contract, error) {
+	p, ok := params.(*ContractParams)
+	if !ok || p == nil {
+		return nil, fmt.Errorf("vhtlc handler requires *vhtlcHandler.ContractParams, got %T", params)
+	}
+	return createContract(p.Opts, keyRef, p.Network)
+}
+
+func (h *Handler) GetKeyRef(c types.Contract) (*identity.KeyRef, error) {
+	keyID, err := requireParam(c, paramOwnerKeyID)
+	if err != nil {
+		return nil, err
+	}
+	pubHex, err := requireParam(c, paramOwnerKey)
+	if err != nil {
+		return nil, err
+	}
+	buf, err := hex.DecodeString(pubHex)
+	if err != nil {
+		return nil, fmt.Errorf("vhtlc contract %s: invalid owner key hex: %w", c.Script, err)
+	}
+	pub, err := schnorr.ParsePubKey(buf)
+	if err != nil {
+		return nil, fmt.Errorf("vhtlc contract %s: invalid owner key: %w", c.Script, err)
+	}
+	return &identity.KeyRef{Id: keyID, PubKey: pub}, nil
+}
+
+func (h *Handler) GetKeyRefs(c types.Contract) (map[string]string, error) {
+	keyRef, err := h.GetKeyRef(c)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{c.Script: keyRef.Id}, nil
+}
+
+func (h *Handler) GetSignerKey(c types.Contract) (*btcec.PublicKey, error) {
+	return parseCompressedParam(c, paramServer)
+}
+
+// GetExitDelay returns the conservative (longest) exit delay:
+// refundWithoutReceiverDelay. This is always safe regardless of
+// whether the wallet is the sender or receiver.
+func (h *Handler) GetExitDelay(c types.Contract) (*arklib.RelativeLocktime, error) {
+	delay, err := parseRelativeLocktime(
+		c, paramRefundWithoutReceiverDelayType, paramRefundWithoutReceiverDelayValue,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &delay, nil
+}
+
+func (h *Handler) GetTapscripts(c types.Contract) ([]string, error) {
+	opts, err := OptsFromContract(c)
+	if err != nil {
+		return nil, err
+	}
+	s, err := vhtlc.NewVHTLCScriptFromOpts(opts)
+	if err != nil {
+		return nil, fmt.Errorf("vhtlc contract %s: rebuild script: %w", c.Script, err)
+	}
+	return s.Encode()
+}
+
+// Compile-time check.
+var _ handlers.Handler = (*Handler)(nil)
+
+// createContract builds a VHTLC contract entry. ownerKeyRef is the wallet's
+// identity key — stored so GetKeyRef can return it for signing.
+func createContract(
+	opts vhtlc.Opts,
+	ownerKeyRef identity.KeyRef,
+	network arklib.Network,
+) (*types.Contract, error) {
+	s, err := vhtlc.NewVHTLCScriptFromOpts(opts)
+	if err != nil {
+		return nil, fmt.Errorf("build vhtlc script: %w", err)
+	}
+	tapKey, _, err := s.TapTree()
+	if err != nil {
+		return nil, fmt.Errorf("compute vhtlc tap tree: %w", err)
+	}
+	pkScript, err := txscript.PayToTaprootScript(tapKey)
+	if err != nil {
+		return nil, fmt.Errorf("compute vhtlc pkScript: %w", err)
+	}
+	addr, err := s.Address(network.Addr)
+	if err != nil {
+		return nil, fmt.Errorf("encode vhtlc address: %w", err)
+	}
+
+	params := map[string]string{
+		paramOwnerKeyID:                      ownerKeyRef.Id,
+		paramOwnerKey:                        hex.EncodeToString(schnorr.SerializePubKey(ownerKeyRef.PubKey)),
+		paramSender:                          hex.EncodeToString(opts.Sender.SerializeCompressed()),
+		paramReceiver:                        hex.EncodeToString(opts.Receiver.SerializeCompressed()),
+		paramServer:                          hex.EncodeToString(opts.Server.SerializeCompressed()),
+		paramPreimageHash:                    hex.EncodeToString(opts.PreimageHash),
+		paramRefundLocktime:                  strconv.FormatUint(uint64(opts.RefundLocktime), 10),
+		paramClaimDelayType:                  locktimeTypeName(opts.UnilateralClaimDelay.Type),
+		paramClaimDelayValue:                 strconv.FormatUint(uint64(opts.UnilateralClaimDelay.Value), 10),
+		paramRefundDelayType:                 locktimeTypeName(opts.UnilateralRefundDelay.Type),
+		paramRefundDelayValue:                strconv.FormatUint(uint64(opts.UnilateralRefundDelay.Value), 10),
+		paramRefundWithoutReceiverDelayType:  locktimeTypeName(opts.UnilateralRefundWithoutReceiverDelay.Type),
+		paramRefundWithoutReceiverDelayValue: strconv.FormatUint(uint64(opts.UnilateralRefundWithoutReceiverDelay.Value), 10),
+	}
+
+	if opts.NonInteractiveClaim != nil {
+		params[paramNICReceiverPkScript] = hex.EncodeToString(opts.NonInteractiveClaim.ReceiverPkScript)
+		params[paramNICIntrospectorPubKey] = hex.EncodeToString(
+			opts.NonInteractiveClaim.IntrospectorPubKey.SerializeCompressed(),
+		)
+	}
+
+	return &types.Contract{
+		Type:      ContractTypeVHTLC,
+		Script:    hex.EncodeToString(pkScript),
+		Address:   addr,
+		Params:    params,
+		State:     types.ContractStateActive,
+		CreatedAt: time.Now(),
+	}, nil
+}
+
+// OptsFromContract reconstructs vhtlc.Opts from a persisted contract's params.
+func OptsFromContract(c types.Contract) (vhtlc.Opts, error) {
+	sender, err := parseCompressedParam(c, paramSender)
+	if err != nil {
+		return vhtlc.Opts{}, err
+	}
+	receiver, err := parseCompressedParam(c, paramReceiver)
+	if err != nil {
+		return vhtlc.Opts{}, err
+	}
+	server, err := parseCompressedParam(c, paramServer)
+	if err != nil {
+		return vhtlc.Opts{}, err
+	}
+	preimageHashHex, err := requireParam(c, paramPreimageHash)
+	if err != nil {
+		return vhtlc.Opts{}, err
+	}
+	preimageHash, err := hex.DecodeString(preimageHashHex)
+	if err != nil {
+		return vhtlc.Opts{}, fmt.Errorf("vhtlc contract %s: invalid preimage hash: %w", c.Script, err)
+	}
+	refundLockStr, err := requireParam(c, paramRefundLocktime)
+	if err != nil {
+		return vhtlc.Opts{}, err
+	}
+	refundLock, err := strconv.ParseUint(refundLockStr, 10, 32)
+	if err != nil {
+		return vhtlc.Opts{}, fmt.Errorf("vhtlc contract %s: invalid refund locktime: %w", c.Script, err)
+	}
+	claimDelay, err := parseRelativeLocktime(c, paramClaimDelayType, paramClaimDelayValue)
+	if err != nil {
+		return vhtlc.Opts{}, err
+	}
+	refundDelay, err := parseRelativeLocktime(c, paramRefundDelayType, paramRefundDelayValue)
+	if err != nil {
+		return vhtlc.Opts{}, err
+	}
+	refundWithoutReceiverDelay, err := parseRelativeLocktime(
+		c, paramRefundWithoutReceiverDelayType, paramRefundWithoutReceiverDelayValue,
+	)
+	if err != nil {
+		return vhtlc.Opts{}, err
+	}
+
+	opts := vhtlc.Opts{
+		Sender:                               sender,
+		Receiver:                             receiver,
+		Server:                               server,
+		PreimageHash:                         preimageHash,
+		RefundLocktime:                       arklib.AbsoluteLocktime(refundLock),
+		UnilateralClaimDelay:                 claimDelay,
+		UnilateralRefundDelay:                refundDelay,
+		UnilateralRefundWithoutReceiverDelay: refundWithoutReceiverDelay,
+	}
+
+	// Non-interactive claim params are optional.
+	if recvHex, ok := c.Params[paramNICReceiverPkScript]; ok && recvHex != "" {
+		recv, err := hex.DecodeString(recvHex)
+		if err != nil {
+			return vhtlc.Opts{}, fmt.Errorf("vhtlc contract %s: invalid NIC receiver pkScript: %w", c.Script, err)
+		}
+		introspector, err := parseCompressedParam(c, paramNICIntrospectorPubKey)
+		if err != nil {
+			return vhtlc.Opts{}, err
+		}
+		opts.NonInteractiveClaim = &vhtlc.NonInteractiveClaimOpts{
+			ReceiverPkScript:   recv,
+			IntrospectorPubKey: introspector,
+		}
+	}
+
+	return opts, nil
+}
+
+// --- helpers ---
+
+func requireParam(c types.Contract, key string) (string, error) {
+	if c.Params == nil {
+		return "", fmt.Errorf("vhtlc contract %s: no params", c.Script)
+	}
+	v, ok := c.Params[key]
+	if !ok || v == "" {
+		return "", fmt.Errorf("vhtlc contract %s: missing param %q", c.Script, key)
+	}
+	return v, nil
+}
+
+func parseCompressedParam(c types.Contract, key string) (*btcec.PublicKey, error) {
+	raw, err := requireParam(c, key)
+	if err != nil {
+		return nil, err
+	}
+	buf, err := hex.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("vhtlc contract %s: invalid %s hex: %w", c.Script, key, err)
+	}
+	pub, err := btcec.ParsePubKey(buf)
+	if err != nil {
+		return nil, fmt.Errorf("vhtlc contract %s: invalid %s: %w", c.Script, key, err)
+	}
+	return pub, nil
+}
+
+func parseRelativeLocktime(
+	c types.Contract, typeKey, valueKey string,
+) (arklib.RelativeLocktime, error) {
+	typeStr, err := requireParam(c, typeKey)
+	if err != nil {
+		return arklib.RelativeLocktime{}, err
+	}
+	valueStr, err := requireParam(c, valueKey)
+	if err != nil {
+		return arklib.RelativeLocktime{}, err
+	}
+	value, err := strconv.ParseUint(valueStr, 10, 32)
+	if err != nil {
+		return arklib.RelativeLocktime{}, fmt.Errorf(
+			"vhtlc contract %s: invalid %s: %w", c.Script, valueKey, err,
+		)
+	}
+	var locktimeType arklib.RelativeLocktimeType
+	switch typeStr {
+	case locktimeTagBlock:
+		locktimeType = arklib.LocktimeTypeBlock
+	case locktimeTagSecond:
+		locktimeType = arklib.LocktimeTypeSecond
+	default:
+		return arklib.RelativeLocktime{}, fmt.Errorf(
+			"vhtlc contract %s: unknown locktime type %q for %s", c.Script, typeStr, typeKey,
+		)
+	}
+	return arklib.RelativeLocktime{Type: locktimeType, Value: uint32(value)}, nil
+}
+
+func locktimeTypeName(t arklib.RelativeLocktimeType) string {
+	switch t {
+	case arklib.LocktimeTypeBlock:
+		return locktimeTagBlock
+	case arklib.LocktimeTypeSecond:
+		return locktimeTagSecond
+	default:
+		return ""
+	}
+}
+

--- a/contract/handlers/vhtlc/handler.go
+++ b/contract/handlers/vhtlc/handler.go
@@ -47,34 +47,33 @@ const (
 // Handler is a stateless contract handler for VHTLC scripts.
 // All VHTLC parameters are stored in Contract.Params, so the handler
 // can rebuild the full tapscript tree from any persisted contract.
-type Handler struct{}
+type Handler struct {
+	network arklib.Network
+}
 
 // NewHandler returns a VHTLC contract handler ready to be registered via
 // WithContractHandler(ContractTypeVHTLC, vhtlcHandler.NewHandler()).
-func NewHandler() *Handler { return &Handler{} }
+func NewHandler(network arklib.Network) *Handler {
+	return &Handler{
+		network: network,
+	}
+}
 
 // Derivable returns false — VHTLC contracts require counterparty data
 // (pubkeys, preimage hash, locktimes) and cannot be derived from an HD key alone.
 // Callers must provide WithParams(*ContractParams) when calling Manager.NewContract.
 func (h *Handler) Derivable() bool { return false }
 
-// ContractParams contains the handler-specific parameters for creating a VHTLC
-// contract. Pass via contract.WithParams(&vhtlcHandler.ContractParams{...}).
-type ContractParams struct {
-	Opts    vhtlc.Opts
-	Network arklib.Network
-}
-
 // NewContract builds a VHTLC contract from the caller-provided key and params.
 // params must be *ContractParams; returns an error otherwise.
 func (h *Handler) NewContract(
 	_ context.Context, keyRef identity.KeyRef, params any,
 ) (*types.Contract, error) {
-	p, ok := params.(*ContractParams)
+	p, ok := params.(*vhtlc.Opts)
 	if !ok || p == nil {
 		return nil, fmt.Errorf("vhtlc handler requires *vhtlcHandler.ContractParams, got %T", params)
 	}
-	return createContract(p.Opts, keyRef, p.Network)
+	return createContract(*p, keyRef, h.network)
 }
 
 func (h *Handler) GetKeyRef(c types.Contract) (*identity.KeyRef, error) {
@@ -339,4 +338,3 @@ func locktimeTypeName(t arklib.RelativeLocktimeType) string {
 		return ""
 	}
 }
-

--- a/contract/handlers/vhtlc/handler.go
+++ b/contract/handlers/vhtlc/handler.go
@@ -163,23 +163,40 @@ func createContract(
 	}
 
 	params := map[string]string{
-		paramOwnerKeyID:                      ownerKeyRef.Id,
-		paramOwnerKey:                        hex.EncodeToString(schnorr.SerializePubKey(ownerKeyRef.PubKey)),
-		paramSender:                          hex.EncodeToString(opts.Sender.SerializeCompressed()),
-		paramReceiver:                        hex.EncodeToString(opts.Receiver.SerializeCompressed()),
-		paramServer:                          hex.EncodeToString(opts.Server.SerializeCompressed()),
-		paramPreimageHash:                    hex.EncodeToString(opts.PreimageHash),
-		paramRefundLocktime:                  strconv.FormatUint(uint64(opts.RefundLocktime), 10),
-		paramClaimDelayType:                  locktimeTypeName(opts.UnilateralClaimDelay.Type),
-		paramClaimDelayValue:                 strconv.FormatUint(uint64(opts.UnilateralClaimDelay.Value), 10),
-		paramRefundDelayType:                 locktimeTypeName(opts.UnilateralRefundDelay.Type),
-		paramRefundDelayValue:                strconv.FormatUint(uint64(opts.UnilateralRefundDelay.Value), 10),
-		paramRefundWithoutReceiverDelayType:  locktimeTypeName(opts.UnilateralRefundWithoutReceiverDelay.Type),
-		paramRefundWithoutReceiverDelayValue: strconv.FormatUint(uint64(opts.UnilateralRefundWithoutReceiverDelay.Value), 10),
+		paramOwnerKeyID: ownerKeyRef.Id,
+		paramOwnerKey: hex.EncodeToString(
+			schnorr.SerializePubKey(ownerKeyRef.PubKey),
+		),
+		paramSender: hex.EncodeToString(opts.Sender.SerializeCompressed()),
+		paramReceiver: hex.EncodeToString(
+			opts.Receiver.SerializeCompressed(),
+		),
+		paramServer:         hex.EncodeToString(opts.Server.SerializeCompressed()),
+		paramPreimageHash:   hex.EncodeToString(opts.PreimageHash),
+		paramRefundLocktime: strconv.FormatUint(uint64(opts.RefundLocktime), 10),
+		paramClaimDelayType: locktimeTypeName(opts.UnilateralClaimDelay.Type),
+		paramClaimDelayValue: strconv.FormatUint(
+			uint64(opts.UnilateralClaimDelay.Value),
+			10,
+		),
+		paramRefundDelayType: locktimeTypeName(opts.UnilateralRefundDelay.Type),
+		paramRefundDelayValue: strconv.FormatUint(
+			uint64(opts.UnilateralRefundDelay.Value),
+			10,
+		),
+		paramRefundWithoutReceiverDelayType: locktimeTypeName(
+			opts.UnilateralRefundWithoutReceiverDelay.Type,
+		),
+		paramRefundWithoutReceiverDelayValue: strconv.FormatUint(
+			uint64(opts.UnilateralRefundWithoutReceiverDelay.Value),
+			10,
+		),
 	}
 
 	if opts.NonInteractiveClaim != nil {
-		params[paramNICReceiverPkScript] = hex.EncodeToString(opts.NonInteractiveClaim.ReceiverPkScript)
+		params[paramNICReceiverPkScript] = hex.EncodeToString(
+			opts.NonInteractiveClaim.ReceiverPkScript,
+		)
 		params[paramNICIntrospectorPubKey] = hex.EncodeToString(
 			opts.NonInteractiveClaim.IntrospectorPubKey.SerializeCompressed(),
 		)
@@ -215,7 +232,11 @@ func OptsFromContract(c types.Contract) (vhtlc.Opts, error) {
 	}
 	preimageHash, err := hex.DecodeString(preimageHashHex)
 	if err != nil {
-		return vhtlc.Opts{}, fmt.Errorf("vhtlc contract %s: invalid preimage hash: %w", c.Script, err)
+		return vhtlc.Opts{}, fmt.Errorf(
+			"vhtlc contract %s: invalid preimage hash: %w",
+			c.Script,
+			err,
+		)
 	}
 	refundLockStr, err := requireParam(c, paramRefundLocktime)
 	if err != nil {
@@ -223,7 +244,11 @@ func OptsFromContract(c types.Contract) (vhtlc.Opts, error) {
 	}
 	refundLock, err := strconv.ParseUint(refundLockStr, 10, 32)
 	if err != nil {
-		return vhtlc.Opts{}, fmt.Errorf("vhtlc contract %s: invalid refund locktime: %w", c.Script, err)
+		return vhtlc.Opts{}, fmt.Errorf(
+			"vhtlc contract %s: invalid refund locktime: %w",
+			c.Script,
+			err,
+		)
 	}
 	claimDelay, err := parseRelativeLocktime(c, paramClaimDelayType, paramClaimDelayValue)
 	if err != nil {
@@ -255,7 +280,11 @@ func OptsFromContract(c types.Contract) (vhtlc.Opts, error) {
 	if recvHex, ok := c.Params[paramNICReceiverPkScript]; ok && recvHex != "" {
 		recv, err := hex.DecodeString(recvHex)
 		if err != nil {
-			return vhtlc.Opts{}, fmt.Errorf("vhtlc contract %s: invalid NIC receiver pkScript: %w", c.Script, err)
+			return vhtlc.Opts{}, fmt.Errorf(
+				"vhtlc contract %s: invalid NIC receiver pkScript: %w",
+				c.Script,
+				err,
+			)
 		}
 		introspector, err := parseCompressedParam(c, paramNICIntrospectorPubKey)
 		if err != nil {

--- a/contract/handlers/vhtlc/handler_test.go
+++ b/contract/handlers/vhtlc/handler_test.go
@@ -1,0 +1,677 @@
+package vhtlcHandler
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/client-lib/identity"
+	"github.com/arkade-os/go-sdk/types"
+	"github.com/arkade-os/go-sdk/vhtlc"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/lightningnetwork/lnd/input"
+	"github.com/stretchr/testify/require"
+)
+
+var testNetwork = arklib.BitcoinRegTest
+
+type invalidCase struct {
+	name          string
+	params        map[string]string
+	expectedError string
+}
+
+func TestVHTLCHandlerNewContract(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		_, keyRef, opts, c := newVHTLCContract(t, newTestVHTLCOpts(t))
+
+		require.Equal(t, ContractTypeVHTLC, c.Type)
+		require.Equal(t, types.ContractStateActive, c.State)
+		require.NotEmpty(t, c.Script)
+		require.NotEmpty(t, c.Address)
+		require.False(t, c.CreatedAt.IsZero())
+		assertVHTLCContract(t, c, keyRef, opts)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		h := NewHandler(testNetwork)
+		keyRef := newTestKeyRef(t)
+
+		t.Run("nil params", func(t *testing.T) {
+			got, err := h.NewContract(t.Context(), keyRef, nil)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "requires *vhtlc.Opts")
+			require.Nil(t, got)
+		})
+
+		t.Run("wrong params type", func(t *testing.T) {
+			got, err := h.NewContract(t.Context(), keyRef, "not-opts")
+			require.Error(t, err)
+			require.ErrorContains(t, err, "requires *vhtlc.Opts")
+			require.Nil(t, got)
+		})
+
+		cases := []struct {
+			name          string
+			mutate        func(*vhtlc.Opts)
+			expectedError string
+		}{
+			{
+				name:          "missing sender",
+				mutate:        func(o *vhtlc.Opts) { o.Sender = nil },
+				expectedError: "missing sender pubkey",
+			},
+			{
+				name:          "missing receiver",
+				mutate:        func(o *vhtlc.Opts) { o.Receiver = nil },
+				expectedError: "missing receiver pubkey",
+			},
+			{
+				name:          "missing server",
+				mutate:        func(o *vhtlc.Opts) { o.Server = nil },
+				expectedError: "missing server pubkey",
+			},
+			{
+				name:          "missing preimage hash",
+				mutate:        func(o *vhtlc.Opts) { o.PreimageHash = nil },
+				expectedError: "missing preimage hash",
+			},
+			{
+				name:          "invalid preimage hash length",
+				mutate:        func(o *vhtlc.Opts) { o.PreimageHash = []byte{0x01, 0x02} },
+				expectedError: "preimage hash must be 20 bytes",
+			},
+			{
+				name:          "zero refund locktime",
+				mutate:        func(o *vhtlc.Opts) { o.RefundLocktime = 0 },
+				expectedError: "refund locktime must be greater than 0",
+			},
+			{
+				name: "invalid claim delay",
+				mutate: func(o *vhtlc.Opts) {
+					o.UnilateralClaimDelay = arklib.RelativeLocktime{
+						Type: arklib.LocktimeTypeSecond, Value: 1,
+					}
+				},
+				expectedError: "invalid unilateral claim delay",
+			},
+			{
+				name: "invalid non-interactive claim",
+				mutate: func(o *vhtlc.Opts) {
+					o.NonInteractiveClaim = &vhtlc.NonInteractiveClaimOpts{
+						ReceiverPkScript:   []byte{0x51},
+						IntrospectorPubKey: newTestPubKey(t),
+					}
+				},
+				expectedError: "receiver pkScript must be 34 bytes",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				opts := newTestVHTLCOpts(t)
+				tc.mutate(opts)
+				got, err := h.NewContract(t.Context(), keyRef, opts)
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+				require.Nil(t, got)
+			})
+		}
+	})
+}
+
+func TestVHTLCHandlerGetKeyRef(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		h, keyRef, _, c := newVHTLCContract(t, newTestVHTLCOpts(t))
+
+		ref, err := h.GetKeyRef(c)
+		require.NoError(t, err)
+		require.NotNil(t, ref)
+		require.Equal(t, keyRef.Id, ref.Id)
+		require.Equal(
+			t,
+			schnorr.SerializePubKey(keyRef.PubKey),
+			schnorr.SerializePubKey(ref.PubKey),
+		)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		h := NewHandler(testNetwork)
+		cases := []invalidCase{
+			{name: "no params", params: nil, expectedError: "no params"},
+			{
+				name:          "missing ownerKeyId",
+				params:        map[string]string{paramOwnerKey: "abcd"},
+				expectedError: "missing param",
+			},
+			{
+				name:          "empty ownerKeyId",
+				params:        map[string]string{paramOwnerKeyID: "", paramOwnerKey: "abcd"},
+				expectedError: "missing param",
+			},
+			{
+				name:          "missing owner key",
+				params:        map[string]string{paramOwnerKeyID: "m/0/0"},
+				expectedError: "missing param",
+			},
+			{
+				name:          "invalid owner key hex",
+				params:        map[string]string{paramOwnerKeyID: "m/0/0", paramOwnerKey: "nothex"},
+				expectedError: "invalid owner key hex",
+			},
+			{
+				name: "invalid owner key",
+				params: map[string]string{
+					paramOwnerKeyID: "m/0/0",
+					paramOwnerKey:   hex.EncodeToString([]byte{0x00, 0x01}),
+				},
+				expectedError: "invalid owner key",
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				ref, err := h.GetKeyRef(types.Contract{Script: "broken", Params: c.params})
+				require.Error(t, err)
+				require.ErrorContains(t, err, c.expectedError)
+				require.Nil(t, ref)
+			})
+		}
+	})
+}
+
+func TestVHTLCHandlerGetKeyRefs(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		h, keyRef, _, c := newVHTLCContract(t, newTestVHTLCOpts(t))
+
+		refs, err := h.GetKeyRefs(c)
+		require.NoError(t, err)
+		require.Len(t, refs, 1)
+		require.Equal(t, keyRef.Id, refs[c.Script])
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		h := NewHandler(testNetwork)
+		cases := []invalidCase{
+			{name: "no params", params: nil, expectedError: "no params"},
+			{
+				name: "invalid owner key",
+				params: map[string]string{
+					paramOwnerKeyID: "m/0/0",
+					paramOwnerKey:   hex.EncodeToString([]byte{0x00, 0x01}),
+				},
+				expectedError: "invalid owner key",
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				refs, err := h.GetKeyRefs(types.Contract{Script: "broken", Params: c.params})
+				require.Error(t, err)
+				require.ErrorContains(t, err, c.expectedError)
+				require.Nil(t, refs)
+			})
+		}
+	})
+}
+
+func TestVHTLCHandlerGetSignerKey(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		h, _, opts, c := newVHTLCContract(t, newTestVHTLCOpts(t))
+
+		signer, err := h.GetSignerKey(c)
+		require.NoError(t, err)
+		require.NotNil(t, signer)
+		require.Equal(t, opts.Server.SerializeCompressed(), signer.SerializeCompressed())
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		h := NewHandler(testNetwork)
+		cases := []invalidCase{
+			{name: "no params", params: nil, expectedError: "no params"},
+			{
+				name:          "missing server key",
+				params:        map[string]string{paramOwnerKeyID: "m/0/0"},
+				expectedError: "missing param",
+			},
+			{
+				name:          "empty server key",
+				params:        map[string]string{paramServer: ""},
+				expectedError: "missing param",
+			},
+			{
+				name:          "invalid server key hex",
+				params:        map[string]string{paramServer: "nothex"},
+				expectedError: "invalid server hex",
+			},
+			{
+				name: "invalid server key",
+				params: map[string]string{
+					paramServer: hex.EncodeToString([]byte{0x00, 0x01}),
+				},
+				expectedError: "invalid server",
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				signer, err := h.GetSignerKey(types.Contract{Script: "broken", Params: c.params})
+				require.Error(t, err)
+				require.ErrorContains(t, err, c.expectedError)
+				require.Nil(t, signer)
+			})
+		}
+	})
+}
+
+func TestVHTLCHandlerGetExitDelay(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		h, _, opts, c := newVHTLCContract(t, newTestVHTLCOpts(t))
+
+		delay, err := h.GetExitDelay(c)
+		require.NoError(t, err)
+		require.NotNil(t, delay)
+		require.Equal(t, opts.UnilateralRefundWithoutReceiverDelay.Type, delay.Type)
+		require.Equal(t, opts.UnilateralRefundWithoutReceiverDelay.Value, delay.Value)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		h := NewHandler(testNetwork)
+		cases := []invalidCase{
+			{name: "no params", params: nil, expectedError: "no params"},
+			{
+				name:          "missing delay type",
+				params:        map[string]string{paramOwnerKeyID: "m/0/0"},
+				expectedError: "missing param",
+			},
+			{
+				name: "missing delay value",
+				params: map[string]string{
+					paramRefundWithoutReceiverDelayType: "second",
+				},
+				expectedError: "missing param",
+			},
+			{
+				name: "invalid delay value",
+				params: map[string]string{
+					paramRefundWithoutReceiverDelayType:  "second",
+					paramRefundWithoutReceiverDelayValue: "notanumber",
+				},
+				expectedError: "invalid",
+			},
+			{
+				name: "unknown delay type",
+				params: map[string]string{
+					paramRefundWithoutReceiverDelayType:  "unknown",
+					paramRefundWithoutReceiverDelayValue: "1024",
+				},
+				expectedError: "unknown locktime type",
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				delay, err := h.GetExitDelay(types.Contract{Script: "broken", Params: c.params})
+				require.Error(t, err)
+				require.ErrorContains(t, err, c.expectedError)
+				require.Nil(t, delay)
+			})
+		}
+	})
+}
+
+func TestVHTLCHandlerGetTapscripts(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		t.Run("standard", func(t *testing.T) {
+			h, _, _, c := newVHTLCContract(t, newTestVHTLCOpts(t))
+
+			scripts, err := h.GetTapscripts(c)
+			require.NoError(t, err)
+			require.Len(t, scripts, 6)
+			for _, s := range scripts {
+				require.NotEmpty(t, s)
+			}
+		})
+
+		t.Run("non-interactive claim", func(t *testing.T) {
+			h, _, _, c := newVHTLCContract(t, newTestVHTLCOptsWithNIC(t))
+
+			scripts, err := h.GetTapscripts(c)
+			require.NoError(t, err)
+			require.Len(t, scripts, 7)
+			for _, s := range scripts {
+				require.NotEmpty(t, s)
+			}
+		})
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		h := NewHandler(testNetwork)
+		cases := []struct {
+			name          string
+			nilParams     bool
+			mutate        func(t *testing.T, p map[string]string)
+			expectedError string
+		}{
+			{name: "no params", nilParams: true, expectedError: "no params"},
+			{
+				name:          "missing sender",
+				mutate:        func(_ *testing.T, p map[string]string) { delete(p, paramSender) },
+				expectedError: "missing param",
+			},
+			{
+				name:          "invalid sender hex",
+				mutate:        func(_ *testing.T, p map[string]string) { p[paramSender] = "nothex" },
+				expectedError: "invalid sender hex",
+			},
+			{
+				name: "invalid sender",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramSender] = hex.EncodeToString([]byte{0x00, 0x01})
+				},
+				expectedError: "invalid sender",
+			},
+			{
+				name:          "missing receiver",
+				mutate:        func(_ *testing.T, p map[string]string) { delete(p, paramReceiver) },
+				expectedError: "missing param",
+			},
+			{
+				name: "invalid receiver hex",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramReceiver] = "nothex"
+				},
+				expectedError: "invalid receiver hex",
+			},
+			{
+				name: "invalid receiver",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramReceiver] = hex.EncodeToString([]byte{0x00, 0x01})
+				},
+				expectedError: "invalid receiver",
+			},
+			{
+				name:          "missing server",
+				mutate:        func(_ *testing.T, p map[string]string) { delete(p, paramServer) },
+				expectedError: "missing param",
+			},
+			{
+				name:          "invalid server hex",
+				mutate:        func(_ *testing.T, p map[string]string) { p[paramServer] = "nothex" },
+				expectedError: "invalid server hex",
+			},
+			{
+				name: "invalid server",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramServer] = hex.EncodeToString([]byte{0x00, 0x01})
+				},
+				expectedError: "invalid server",
+			},
+			{
+				name: "missing preimage hash",
+				mutate: func(_ *testing.T, p map[string]string) {
+					delete(p, paramPreimageHash)
+				},
+				expectedError: "missing param",
+			},
+			{
+				name: "invalid preimage hash hex",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramPreimageHash] = "nothex"
+				},
+				expectedError: "invalid preimage hash",
+			},
+			{
+				name: "invalid preimage hash length",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramPreimageHash] = hex.EncodeToString([]byte{0x01, 0x02})
+				},
+				expectedError: "preimage hash must be 20 bytes",
+			},
+			{
+				name: "missing refund locktime",
+				mutate: func(_ *testing.T, p map[string]string) {
+					delete(p, paramRefundLocktime)
+				},
+				expectedError: "missing param",
+			},
+			{
+				name: "invalid refund locktime",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramRefundLocktime] = "notanumber"
+				},
+				expectedError: "invalid refund locktime",
+			},
+			{
+				name: "zero refund locktime",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramRefundLocktime] = "0"
+				},
+				expectedError: "refund locktime must be greater than 0",
+			},
+			{
+				name: "missing claim delay type",
+				mutate: func(_ *testing.T, p map[string]string) {
+					delete(p, paramClaimDelayType)
+				},
+				expectedError: "missing param",
+			},
+			{
+				name: "missing claim delay value",
+				mutate: func(_ *testing.T, p map[string]string) {
+					delete(p, paramClaimDelayValue)
+				},
+				expectedError: "missing param",
+			},
+			{
+				name: "invalid claim delay value",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramClaimDelayValue] = "notanumber"
+				},
+				expectedError: "invalid claimDelayValue",
+			},
+			{
+				name: "unknown claim delay type",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramClaimDelayType] = "unknown"
+				},
+				expectedError: "unknown locktime type",
+			},
+			{
+				name: "missing refund delay type",
+				mutate: func(_ *testing.T, p map[string]string) {
+					delete(p, paramRefundDelayType)
+				},
+				expectedError: "missing param",
+			},
+			{
+				name: "invalid refund delay value",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramRefundDelayValue] = "notanumber"
+				},
+				expectedError: "invalid refundDelayValue",
+			},
+			{
+				name: "unknown refund delay type",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramRefundDelayType] = "unknown"
+				},
+				expectedError: "unknown locktime type",
+			},
+			{
+				name: "missing refund without receiver delay type",
+				mutate: func(_ *testing.T, p map[string]string) {
+					delete(p, paramRefundWithoutReceiverDelayType)
+				},
+				expectedError: "missing param",
+			},
+			{
+				name: "missing refund without receiver delay value",
+				mutate: func(_ *testing.T, p map[string]string) {
+					delete(p, paramRefundWithoutReceiverDelayValue)
+				},
+				expectedError: "missing param",
+			},
+			{
+				name: "invalid refund without receiver delay value",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramRefundWithoutReceiverDelayValue] = "notanumber"
+				},
+				expectedError: "invalid refundWithoutReceiverDelayValue",
+			},
+			{
+				name: "unknown refund without receiver delay type",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramRefundWithoutReceiverDelayType] = "unknown"
+				},
+				expectedError: "unknown locktime type",
+			},
+			{
+				name: "invalid NIC receiver pkScript hex",
+				mutate: func(_ *testing.T, p map[string]string) {
+					p[paramNICReceiverPkScript] = "nothex"
+				},
+				expectedError: "invalid NIC receiver pkScript",
+			},
+			{
+				name: "missing NIC introspector key",
+				mutate: func(t *testing.T, p map[string]string) {
+					p[paramNICReceiverPkScript] = hex.EncodeToString(newTestP2TRPkScript(t))
+					delete(p, paramNICIntrospectorPubKey)
+				},
+				expectedError: "missing param",
+			},
+			{
+				name: "invalid NIC introspector key hex",
+				mutate: func(t *testing.T, p map[string]string) {
+					p[paramNICReceiverPkScript] = hex.EncodeToString(newTestP2TRPkScript(t))
+					p[paramNICIntrospectorPubKey] = "nothex"
+				},
+				expectedError: "invalid nicIntrospectorPubKey hex",
+			},
+			{
+				name: "invalid NIC introspector key",
+				mutate: func(t *testing.T, p map[string]string) {
+					p[paramNICReceiverPkScript] = hex.EncodeToString(newTestP2TRPkScript(t))
+					p[paramNICIntrospectorPubKey] = hex.EncodeToString([]byte{0x00, 0x01})
+				},
+				expectedError: "invalid nicIntrospectorPubKey",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				var params map[string]string
+				if !tc.nilParams {
+					params = newVHTLCParams(t)
+					tc.mutate(t, params)
+				}
+				scripts, err := h.GetTapscripts(types.Contract{Script: "broken", Params: params})
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+				require.Nil(t, scripts)
+			})
+		}
+	})
+}
+
+func newVHTLCContract(
+	t *testing.T, opts *vhtlc.Opts,
+) (*Handler, identity.KeyRef, *vhtlc.Opts, types.Contract) {
+	t.Helper()
+	h := NewHandler(testNetwork)
+	keyRef := newTestKeyRef(t)
+	built, err := h.NewContract(t.Context(), keyRef, opts)
+	require.NoError(t, err)
+	return h, keyRef, opts, *built
+}
+
+func newVHTLCParams(t *testing.T) map[string]string {
+	t.Helper()
+	_, _, _, c := newVHTLCContract(t, newTestVHTLCOpts(t))
+	return copyParams(c.Params)
+}
+
+func copyParams(params map[string]string) map[string]string {
+	cp := make(map[string]string, len(params))
+	for k, v := range params {
+		cp[k] = v
+	}
+	return cp
+}
+
+func newTestVHTLCOpts(t *testing.T) *vhtlc.Opts {
+	t.Helper()
+	preimage := make([]byte, 32)
+	_, err := rand.Read(preimage)
+	require.NoError(t, err)
+	sha256Hash := sha256.Sum256(preimage)
+
+	return &vhtlc.Opts{
+		Sender:         newTestPubKey(t),
+		Receiver:       newTestPubKey(t),
+		Server:         newTestPubKey(t),
+		PreimageHash:   input.Ripemd160H(sha256Hash[:]),
+		RefundLocktime: arklib.AbsoluteLocktime(1577836800),
+		UnilateralClaimDelay: arklib.RelativeLocktime{
+			Type: arklib.LocktimeTypeSecond, Value: 512,
+		},
+		UnilateralRefundDelay: arklib.RelativeLocktime{
+			Type: arklib.LocktimeTypeSecond, Value: 512,
+		},
+		UnilateralRefundWithoutReceiverDelay: arklib.RelativeLocktime{
+			Type: arklib.LocktimeTypeSecond, Value: 1024,
+		},
+	}
+}
+
+func newTestVHTLCOptsWithNIC(t *testing.T) *vhtlc.Opts {
+	t.Helper()
+	opts := newTestVHTLCOpts(t)
+	opts.NonInteractiveClaim = &vhtlc.NonInteractiveClaimOpts{
+		ReceiverPkScript:   newTestP2TRPkScript(t),
+		IntrospectorPubKey: newTestPubKey(t),
+	}
+	return opts
+}
+
+func newTestKeyRef(t *testing.T) identity.KeyRef {
+	t.Helper()
+	return identity.KeyRef{Id: "m/0/0", PubKey: newTestPubKey(t)}
+}
+
+func newTestPubKey(t *testing.T) *btcec.PublicKey {
+	t.Helper()
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	return priv.PubKey()
+}
+
+func newTestP2TRPkScript(t *testing.T) []byte {
+	t.Helper()
+	pkScript, err := txscript.PayToTaprootScript(newTestPubKey(t))
+	require.NoError(t, err)
+	return pkScript
+}
+
+func assertVHTLCContract(
+	t *testing.T, c types.Contract, keyRef identity.KeyRef, opts *vhtlc.Opts,
+) {
+	t.Helper()
+	require.Equal(t, keyRef.Id, c.Params[paramOwnerKeyID])
+	require.Equal(
+		t,
+		hex.EncodeToString(schnorr.SerializePubKey(keyRef.PubKey)),
+		c.Params[paramOwnerKey],
+	)
+	require.Equal(
+		t,
+		hex.EncodeToString(opts.Server.SerializeCompressed()),
+		c.Params[paramServer],
+	)
+	require.Contains(t, c.Address, testNetwork.Addr)
+}

--- a/contract/manager.go
+++ b/contract/manager.go
@@ -84,6 +84,9 @@ func (m *contractManager) ScanContracts(ctx context.Context, gapLimit uint32) er
 		if err != nil {
 			return err
 		}
+		if !handler.Derivable() {
+			continue
+		}
 		// Pick the "is this contract used externally?" probe for the type:
 		// boarding contracts are looked up via the explorer per-address (and
 		// throttled), offchain ones via the indexer's batch GetVtxos.
@@ -120,21 +123,20 @@ func (m *contractManager) NewContract(
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.keyProvider.GetType() == identity.SingleKeyIdentity {
-		// A single-key identity reuses the same key for every contract of a given type, so the
-		// derived script is identical across calls. Treat a repeat as idempotent reuse and return
-		// the stored contract.
+	// Derivable single-key contracts are idempotent: the same key always
+	// produces the same script, so return the existing one.
+	if handler.Derivable() && m.keyProvider.GetType() == identity.SingleKeyIdentity {
 		contracts, err := m.store.GetContractsByType(ctx, contractType)
 		if err != nil {
 			return nil, err
 		}
 		if len(contracts) > 0 {
-			contract := contracts[0]
-			return &contract, nil
+			c := contracts[0]
+			return &c, nil
 		}
 	}
 
-	contract, err := m.newContract(ctx, contractType, handler)
+	contract, err := m.deriveContract(ctx, contractType, handler, o.params)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +146,6 @@ func (m *contractManager) NewContract(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get key ref for contract %s: %w", contract.Script, err)
 	}
-
 	keyIndex, err := m.keyProvider.GetKeyIndex(ctx, keyRef.Id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get key index for contract %s: %w", contract.Script, err)
@@ -154,7 +155,7 @@ func (m *contractManager) NewContract(
 		return nil, fmt.Errorf("failed to store contract: %w", err)
 	}
 
-	log.Debugf("%s added new contract %s", logPrefix, contract.Script)
+	log.Debugf("%s added new %s contract %s", logPrefix, contractType, contract.Script)
 
 	return contract, nil
 }
@@ -274,7 +275,7 @@ scan:
 			if err != nil {
 				return err
 			}
-			contract, err := handler.NewContract(ctx, *keyRef)
+			contract, err := handler.NewContract(ctx, *keyRef, nil)
 			if err != nil {
 				return fmt.Errorf(
 					"failed to derive %s contract for key %s: %w",
@@ -325,9 +326,9 @@ scan:
 	return nil
 }
 
-func (m *contractManager) newContract(
+func (m *contractManager) deriveContract(
 	ctx context.Context,
-	contractType types.ContractType, handler handlers.Handler,
+	contractType types.ContractType, handler handlers.Handler, params any,
 ) (*types.Contract, error) {
 	contract, err := m.store.GetLatestContract(ctx, contractType)
 	if err != nil {
@@ -355,7 +356,7 @@ func (m *contractManager) newContract(
 		return nil, fmt.Errorf("failed to derive key for contract: %w", err)
 	}
 
-	return handler.NewContract(ctx, *keyRef)
+	return handler.NewContract(ctx, *keyRef, params)
 }
 
 func (m *contractManager) findUsedContracts(
@@ -422,6 +423,9 @@ func (m *contractManager) scanSingleKeyContracts(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		if !handler.Derivable() {
+			continue
+		}
 		contracts, err := m.store.GetContractsByType(ctx, contractType)
 		if err != nil {
 			return err
@@ -441,7 +445,7 @@ func (m *contractManager) scanSingleKeyContracts(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		c, err := handler.NewContract(ctx, *keyRef)
+		c, err := handler.NewContract(ctx, *keyRef, nil)
 		if err != nil {
 			return fmt.Errorf(
 				"failed to derive %s contract for key %s: %w", contractType, keyId, err,

--- a/contract/opts.go
+++ b/contract/opts.go
@@ -125,8 +125,25 @@ func WithLabel(label string) ContractOption {
 	})
 }
 
+// WithParams passes handler-specific parameters for contract creation.
+// Each handler type documents its expected concrete type
+// (e.g. *vhtlcHandler.ContractParams for VHTLC contracts).
+func WithParams(params any) ContractOption {
+	return contractOptFn(func(o *contractOptions) error {
+		if o.params != nil {
+			return fmt.Errorf("params option is already set")
+		}
+		if params == nil {
+			return fmt.Errorf("params must not be nil")
+		}
+		o.params = params
+		return nil
+	})
+}
+
 type contractOptions struct {
-	label string
+	label  string
+	params any
 }
 
 func newDefaultContractOption() *contractOptions {

--- a/contract/opts_test.go
+++ b/contract/opts_test.go
@@ -274,7 +274,9 @@ func newMockHandler(ctType string) handlers.Handler {
 const mockOwnerKeyIdParam = "ownerKeyId"
 
 func (m *mockHandler) Derivable() bool { return true }
-func (m *mockHandler) NewContract(_ context.Context, k identity.KeyRef, _ any) (*types.Contract, error) {
+func (m *mockHandler) NewContract(
+	_ context.Context, k identity.KeyRef, _ any,
+) (*types.Contract, error) {
 	return &types.Contract{
 		Type:    types.ContractType(m.ctType),
 		State:   types.ContractStateActive,

--- a/contract/opts_test.go
+++ b/contract/opts_test.go
@@ -273,7 +273,8 @@ func newMockHandler(ctType string) handlers.Handler {
 
 const mockOwnerKeyIdParam = "ownerKeyId"
 
-func (m *mockHandler) NewContract(_ context.Context, k identity.KeyRef) (*types.Contract, error) {
+func (m *mockHandler) Derivable() bool { return true }
+func (m *mockHandler) NewContract(_ context.Context, k identity.KeyRef, _ any) (*types.Contract, error) {
 	return &types.Contract{
 		Type:    types.ContractType(m.ctType),
 		State:   types.ContractStateActive,

--- a/contract/types.go
+++ b/contract/types.go
@@ -23,8 +23,9 @@ type Manager interface {
 	// ScanContracts looks for untracked contracts to store of any type, and for each of them stops
 	// when gapLimit consecutive unused contracts have been found.
 	ScanContracts(ctx context.Context, gapLimit uint32) error
-	// NewContract creates and stores a new contract. The key is derived from the key provider,
-	// all required parameters are fetched by the proper handler based on the contract type.
+	// NewContract creates and stores a new contract. The key is always derived
+	// from the wallet's identity provider. Non-derivable types (VHTLC, delegate)
+	// require WithParams with handler-specific parameters.
 	NewContract(
 		ctx context.Context, contractType types.ContractType, opts ...ContractOption,
 	) (*types.Contract, error)

--- a/contract/utils_test.go
+++ b/contract/utils_test.go
@@ -262,7 +262,7 @@ func newMockedEnv(t *testing.T) *mockedEnv {
 		t.Helper()
 		keyRef, err := wsvc.GetKey(t.Context(), keyId)
 		require.NoError(t, err)
-		c, err := offchainHandler.NewContract(t.Context(), *keyRef)
+		c, err := offchainHandler.NewContract(t.Context(), *keyRef, nil)
 		require.NoError(t, err)
 		return *c
 	}
@@ -270,7 +270,7 @@ func newMockedEnv(t *testing.T) *mockedEnv {
 		t.Helper()
 		keyRef, err := wsvc.GetKey(t.Context(), keyId)
 		require.NoError(t, err)
-		c, err := boardingHandler.NewContract(t.Context(), *keyRef)
+		c, err := boardingHandler.NewContract(t.Context(), *keyRef, nil)
 		require.NoError(t, err)
 		return *c
 	}
@@ -354,8 +354,9 @@ type mockedHandler struct {
 	mock.Mock
 }
 
+func (h *mockedHandler) Derivable() bool { return true }
 func (h *mockedHandler) NewContract(
-	ctx context.Context, k identity.KeyRef,
+	ctx context.Context, k identity.KeyRef, params any,
 ) (*types.Contract, error) {
 	a := h.Called(ctx, k)
 	c, _ := a.Get(0).(*types.Contract)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.3
 replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v2.3.3
 
 require (
+	github.com/ArkLabsHQ/introspector/pkg/arkade v0.0.0-20260501150319-697f94f40245
 	github.com/arkade-os/arkd/pkg/ark-lib v0.8.1-0.20260429091057-9246f043c4c8
 	github.com/arkade-os/arkd/pkg/client-lib v0.0.0-20260522091257-f2fa2963ea96
 	github.com/btcsuite/btcd v0.24.3-0.20240921052913-67b8efd3ba53
@@ -15,6 +16,7 @@ require (
 	github.com/btcsuite/btcwallet v0.16.10-0.20240718224643-db3a4a2543bd
 	github.com/go-co-op/gocron v1.37.0
 	github.com/golang-migrate/migrate/v4 v4.17.1
+	github.com/lightningnetwork/lnd v0.18.2-beta
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
 	github.com/tyler-smith/go-bip39 v1.1.0
@@ -24,7 +26,6 @@ require (
 
 require (
 	cel.dev/expr v0.25.1 // indirect
-	github.com/ArkLabsHQ/introspector/pkg/arkade v0.0.0-20260501150319-697f94f40245 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
@@ -60,7 +61,6 @@ require (
 	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf // indirect
 	github.com/lightninglabs/neutrino v0.16.1-0.20240425105051-602843d34ffd // indirect
 	github.com/lightninglabs/neutrino/cache v1.1.2 // indirect
-	github.com/lightningnetwork/lnd v0.18.2-beta // indirect
 	github.com/lightningnetwork/lnd/clock v1.1.1 // indirect
 	github.com/lightningnetwork/lnd/fn v1.2.1 // indirect
 	github.com/lightningnetwork/lnd/queue v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 
 require (
 	cel.dev/expr v0.25.1 // indirect
+	github.com/ArkLabsHQ/introspector/pkg/arkade v0.0.0-20260501150319-697f94f40245 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
@@ -42,7 +43,7 @@ require (
 	github.com/containerd/continuity v0.4.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/decred/dcrd/lru v1.1.3 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/ArkLabsHQ/introspector/pkg/arkade v0.0.0-20260501150319-697f94f40245 h1:XY9rtnOftkRRdavt8qOSb65MZ699DG4iUVckdh9ccUw=
 github.com/ArkLabsHQ/introspector/pkg/arkade v0.0.0-20260501150319-697f94f40245/go.mod h1:o+zZ7XnasZwQMGIGbArFCUknUQY1b/j46yvDO55b+RQ=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
@@ -90,8 +92,6 @@ github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn
 github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U0x++OzVrdms8=
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnNEcHYvcCuK6dPZSg=
-github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/ArkLabsHQ/introspector/pkg/arkade v0.0.0-20260501150319-697f94f40245 h1:XY9rtnOftkRRdavt8qOSb65MZ699DG4iUVckdh9ccUw=
+github.com/ArkLabsHQ/introspector/pkg/arkade v0.0.0-20260501150319-697f94f40245/go.mod h1:o+zZ7XnasZwQMGIGbArFCUknUQY1b/j46yvDO55b+RQ=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -90,6 +92,8 @@ github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPc
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnNEcHYvcCuK6dPZSg=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
 github.com/decred/dcrd/lru v1.1.3 h1:w9EAbvGLyzm6jTjF83UKuqZEiUtJmvRhQDOCEIvSuE0=
 github.com/decred/dcrd/lru v1.1.3/go.mod h1:Tw0i0pJyiLEx/oZdHLe1Wdv/Y7EGzAX+sYftnmxBR4o=

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -76,6 +76,13 @@ func ValidateHandler(h handlers.Handler, t types.ContractType) error {
 }
 
 func handlerSanityCheck(h handlers.Handler, t types.ContractType) error {
+	// Non-derivable handlers (VHTLC, delegate, covenant) cannot produce valid
+	// contracts from a random key — they require external state. Skip the
+	// full NewContract → getter chain check for these types.
+	if !h.Derivable() {
+		return nil
+	}
+
 	buf := make([]byte, 32)
 	if _, err := rand.Read(buf); err != nil {
 		return err
@@ -91,7 +98,7 @@ func handlerSanityCheck(h handlers.Handler, t types.ContractType) error {
 		Id:     randomId,
 		PubKey: randomKey.PubKey(),
 	}
-	c, err := h.NewContract(context.Background(), fakeId)
+	c, err := h.NewContract(context.Background(), fakeId, nil)
 	if err != nil {
 		return fmt.Errorf("custom handler NewContract fails: %w", err)
 	}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -292,8 +292,10 @@ type mockedHandler struct {
 	mock.Mock
 }
 
+func (h *mockedHandler) Derivable() bool { return true }
+
 func (h *mockedHandler) NewContract(
-	ctx context.Context, k identity.KeyRef,
+	ctx context.Context, k identity.KeyRef, params any,
 ) (*types.Contract, error) {
 	a := h.Called(ctx, k)
 	c, _ := a.Get(0).(*types.Contract)

--- a/test/e2e/custom_handler_test.go
+++ b/test/e2e/custom_handler_test.go
@@ -63,8 +63,9 @@ func TestCustomContractHandlerRegistered(t *testing.T) {
 // registration without exercising the contract lifecycle.
 type customTestHandler struct{ typ types.ContractType }
 
+func (h *customTestHandler) Derivable() bool { return true }
 func (h *customTestHandler) NewContract(
-	_ context.Context, k identity.KeyRef,
+	_ context.Context, k identity.KeyRef, _ any,
 ) (*types.Contract, error) {
 	s := sha256.Sum256([]byte(string(h.typ) + ":" + k.Id))
 	return &types.Contract{

--- a/vhtlc/noninteractive.go
+++ b/vhtlc/noninteractive.go
@@ -3,9 +3,9 @@ package vhtlc
 import (
 	"fmt"
 
+	"github.com/ArkLabsHQ/introspector/pkg/arkade"
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 )
 
@@ -13,14 +13,16 @@ const p2trPkScriptLen = 34
 
 // NonInteractiveClaimOpts enables the non-interactive claim covenant closure
 // on a VHTLC. When set, NewVHTLCScriptFromOpts appends a ConditionMultisigClosure
-// that lets a solver bot claim the VHTLC on the receiver's behalf by revealing
-// the preimage. The solver does not need any signature from the receiver — it
-// satisfies the introspector-tweaked multisig via the EnforcePayTo arkade script.
+// that lets a solver bot claim the VHTLC on the receiver's behalf
+// by revealing the preimage. The solver does not need any signature from the
+// receiver — it satisfies the introspector-tweaked multisig via the
+// EnforcePayTo arkade script.
+// Thus, the receiver knows that the output script of the claim is going to its wallet
 type NonInteractiveClaimOpts struct {
 	// ReceiverPkScript is the 34-byte P2TR pkScript of the VHTLC receiver.
 	ReceiverPkScript []byte
 	// IntrospectorPubKey is the solver's introspector signing key (compressed).
-	// It will be tweaked with the non-interactive claim arkade script hash.
+	// it will be tweaked with the non interactive claim arkade script.
 	IntrospectorPubKey *btcec.PublicKey
 }
 
@@ -39,20 +41,9 @@ func (o NonInteractiveClaimOpts) validate() error {
 	return nil
 }
 
-// Arkade opcode constants used in the enforcement script.
-// These are custom opcodes defined in the introspector VM (forked from btcd),
-// NOT standard Bitcoin opcodes. They only execute inside the introspector process.
-const (
-	opPushCurrentInputIndex      = 0xcd
-	opInspectOutputScriptPubKey  = 0xd1
-	opInspectOutputValue         = 0xcf
-	opInspectInputValue          = 0xc9
-	opGreaterThanOrEqual         = 0xf4
-)
-
-// EnforcePayTo builds the arkade enforcement script pinning output[i] to
+// enforcePayTo builds the arkade enforcement script pinning output[i] to
 // receiverPkScript with output[i].value >= input[i].value.
-func EnforcePayTo(receiverPkScript []byte) ([]byte, error) {
+func enforcePayTo(receiverPkScript []byte) ([]byte, error) {
 	if len(receiverPkScript) != p2trPkScriptLen {
 		return nil, fmt.Errorf(
 			"expected %d-byte P2TR pkScript, got %d", p2trPkScriptLen, len(receiverPkScript),
@@ -60,51 +51,29 @@ func EnforcePayTo(receiverPkScript []byte) ([]byte, error) {
 	}
 	witnessProgram := receiverPkScript[2:]
 	b := txscript.NewScriptBuilder()
-	b.AddOp(opPushCurrentInputIndex)
-	b.AddOp(txscript.OP_DUP)
-	b.AddOp(opInspectOutputScriptPubKey)
-	b.AddOp(txscript.OP_1)
-	b.AddOp(txscript.OP_EQUALVERIFY)
+	b.AddOp(arkade.OP_PUSHCURRENTINPUTINDEX)
+	b.AddOp(arkade.OP_DUP)
+	b.AddOp(arkade.OP_INSPECTOUTPUTSCRIPTPUBKEY)
+	b.AddOp(arkade.OP_1)
+	b.AddOp(arkade.OP_EQUALVERIFY)
 	b.AddData(witnessProgram)
-	b.AddOp(txscript.OP_EQUALVERIFY)
-	b.AddOp(opInspectOutputValue)
-	b.AddOp(opPushCurrentInputIndex)
-	b.AddOp(opInspectInputValue)
-	b.AddOp(opGreaterThanOrEqual)
+	b.AddOp(arkade.OP_EQUALVERIFY)
+	b.AddOp(arkade.OP_INSPECTOUTPUTVALUE)
+	b.AddOp(arkade.OP_PUSHCURRENTINPUTINDEX)
+	b.AddOp(arkade.OP_INSPECTINPUTVALUE)
+	b.AddOp(arkade.OP_GREATERTHANOREQUAL)
 	return b.Script()
 }
 
-// ArkadeScriptHash computes the tagged hash of an arkade script.
-// This is the canonical hash used for key tweaking.
-var tagArkScriptHash = []byte("ArkScriptHash")
-
-func ArkadeScriptHash(arkadeScript []byte) []byte {
-	hash := chainhash.TaggedHash(tagArkScriptHash, arkadeScript)
-	return hash[:]
-}
-
-// IntrospectorTweakedKey returns the introspector pubkey tweaked by the
-// arkade script hash: tweakedPub = introPub + H(arkadeScript) * G.
-func IntrospectorTweakedKey(
+// introspectorTweakedKey returns the introspector pubkey tweaked by the
+// arkade script hash. It is the second pubkey in the non-interactive claim
+// multisig.
+func introspectorTweakedKey(
 	arkadeScript []byte, introspectorPubKey *btcec.PublicKey,
 ) *btcec.PublicKey {
-	scriptHash := ArkadeScriptHash(arkadeScript)
-	tweakKey, _ := btcec.PrivKeyFromBytes(scriptHash)
-
-	var (
-		pubKeyJacobian btcec.JacobianPoint
-		tweakJacobian  btcec.JacobianPoint
-		resultJacobian btcec.JacobianPoint
+	return arkade.ComputeArkadeScriptPublicKey(
+		introspectorPubKey, arkade.ArkadeScriptHash(arkadeScript),
 	)
-
-	// Normalize to even Y before adding.
-	evenPub, _ := btcec.ParsePubKey(introspectorPubKey.SerializeCompressed())
-	evenPub.AsJacobian(&pubKeyJacobian)
-	btcec.ScalarBaseMultNonConst(&tweakKey.Key, &tweakJacobian)
-	btcec.AddNonConst(&pubKeyJacobian, &tweakJacobian, &resultJacobian)
-	resultJacobian.ToAffine()
-
-	return btcec.NewPublicKey(&resultJacobian.X, &resultJacobian.Y)
 }
 
 // nonInteractiveClaimClosure builds the ConditionMultisigClosure used by the
@@ -114,11 +83,11 @@ func nonInteractiveClaimClosure(
 	opts NonInteractiveClaimOpts,
 	serverPubKey *btcec.PublicKey,
 ) (*script.ConditionMultisigClosure, error) {
-	enforcement, err := EnforcePayTo(opts.ReceiverPkScript)
+	enforcement, err := enforcePayTo(opts.ReceiverPkScript)
 	if err != nil {
 		return nil, err
 	}
-	tweaked := IntrospectorTweakedKey(enforcement, opts.IntrospectorPubKey)
+	tweaked := introspectorTweakedKey(enforcement, opts.IntrospectorPubKey)
 	return &script.ConditionMultisigClosure{
 		MultisigClosure: script.MultisigClosure{
 			PubKeys: []*btcec.PublicKey{serverPubKey, tweaked},

--- a/vhtlc/noninteractive.go
+++ b/vhtlc/noninteractive.go
@@ -1,0 +1,128 @@
+package vhtlc
+
+import (
+	"fmt"
+
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+)
+
+const p2trPkScriptLen = 34
+
+// NonInteractiveClaimOpts enables the non-interactive claim covenant closure
+// on a VHTLC. When set, NewVHTLCScriptFromOpts appends a ConditionMultisigClosure
+// that lets a solver bot claim the VHTLC on the receiver's behalf by revealing
+// the preimage. The solver does not need any signature from the receiver — it
+// satisfies the introspector-tweaked multisig via the EnforcePayTo arkade script.
+type NonInteractiveClaimOpts struct {
+	// ReceiverPkScript is the 34-byte P2TR pkScript of the VHTLC receiver.
+	ReceiverPkScript []byte
+	// IntrospectorPubKey is the solver's introspector signing key (compressed).
+	// It will be tweaked with the non-interactive claim arkade script hash.
+	IntrospectorPubKey *btcec.PublicKey
+}
+
+func (o NonInteractiveClaimOpts) validate() error {
+	if len(o.ReceiverPkScript) != p2trPkScriptLen {
+		return fmt.Errorf(
+			"non-interactive claim: receiver pkScript must be %d bytes", p2trPkScriptLen,
+		)
+	}
+	if o.ReceiverPkScript[0] != txscript.OP_1 || o.ReceiverPkScript[1] != txscript.OP_DATA_32 {
+		return fmt.Errorf("non-interactive claim: receiver pkScript is not P2TR")
+	}
+	if o.IntrospectorPubKey == nil {
+		return fmt.Errorf("non-interactive claim: introspector pubkey must not be nil")
+	}
+	return nil
+}
+
+// Arkade opcode constants used in the enforcement script.
+// These are custom opcodes defined in the introspector VM (forked from btcd),
+// NOT standard Bitcoin opcodes. They only execute inside the introspector process.
+const (
+	opPushCurrentInputIndex      = 0xcd
+	opInspectOutputScriptPubKey  = 0xd1
+	opInspectOutputValue         = 0xcf
+	opInspectInputValue          = 0xc9
+	opGreaterThanOrEqual         = 0xf4
+)
+
+// EnforcePayTo builds the arkade enforcement script pinning output[i] to
+// receiverPkScript with output[i].value >= input[i].value.
+func EnforcePayTo(receiverPkScript []byte) ([]byte, error) {
+	if len(receiverPkScript) != p2trPkScriptLen {
+		return nil, fmt.Errorf(
+			"expected %d-byte P2TR pkScript, got %d", p2trPkScriptLen, len(receiverPkScript),
+		)
+	}
+	witnessProgram := receiverPkScript[2:]
+	b := txscript.NewScriptBuilder()
+	b.AddOp(opPushCurrentInputIndex)
+	b.AddOp(txscript.OP_DUP)
+	b.AddOp(opInspectOutputScriptPubKey)
+	b.AddOp(txscript.OP_1)
+	b.AddOp(txscript.OP_EQUALVERIFY)
+	b.AddData(witnessProgram)
+	b.AddOp(txscript.OP_EQUALVERIFY)
+	b.AddOp(opInspectOutputValue)
+	b.AddOp(opPushCurrentInputIndex)
+	b.AddOp(opInspectInputValue)
+	b.AddOp(opGreaterThanOrEqual)
+	return b.Script()
+}
+
+// ArkadeScriptHash computes the tagged hash of an arkade script.
+// This is the canonical hash used for key tweaking.
+var tagArkScriptHash = []byte("ArkScriptHash")
+
+func ArkadeScriptHash(arkadeScript []byte) []byte {
+	hash := chainhash.TaggedHash(tagArkScriptHash, arkadeScript)
+	return hash[:]
+}
+
+// IntrospectorTweakedKey returns the introspector pubkey tweaked by the
+// arkade script hash: tweakedPub = introPub + H(arkadeScript) * G.
+func IntrospectorTweakedKey(
+	arkadeScript []byte, introspectorPubKey *btcec.PublicKey,
+) *btcec.PublicKey {
+	scriptHash := ArkadeScriptHash(arkadeScript)
+	tweakKey, _ := btcec.PrivKeyFromBytes(scriptHash)
+
+	var (
+		pubKeyJacobian btcec.JacobianPoint
+		tweakJacobian  btcec.JacobianPoint
+		resultJacobian btcec.JacobianPoint
+	)
+
+	// Normalize to even Y before adding.
+	evenPub, _ := btcec.ParsePubKey(introspectorPubKey.SerializeCompressed())
+	evenPub.AsJacobian(&pubKeyJacobian)
+	btcec.ScalarBaseMultNonConst(&tweakKey.Key, &tweakJacobian)
+	btcec.AddNonConst(&pubKeyJacobian, &tweakJacobian, &resultJacobian)
+	resultJacobian.ToAffine()
+
+	return btcec.NewPublicKey(&resultJacobian.X, &resultJacobian.Y)
+}
+
+// nonInteractiveClaimClosure builds the ConditionMultisigClosure used by the
+// solver to claim the VHTLC unilaterally with the preimage.
+func nonInteractiveClaimClosure(
+	preimageCondition []byte,
+	opts NonInteractiveClaimOpts,
+	serverPubKey *btcec.PublicKey,
+) (*script.ConditionMultisigClosure, error) {
+	enforcement, err := EnforcePayTo(opts.ReceiverPkScript)
+	if err != nil {
+		return nil, err
+	}
+	tweaked := IntrospectorTweakedKey(enforcement, opts.IntrospectorPubKey)
+	return &script.ConditionMultisigClosure{
+		MultisigClosure: script.MultisigClosure{
+			PubKeys: []*btcec.PublicKey{serverPubKey, tweaked},
+		},
+		Condition: preimageCondition,
+	}, nil
+}

--- a/vhtlc/opts.go
+++ b/vhtlc/opts.go
@@ -1,0 +1,131 @@
+package vhtlc
+
+import (
+	"fmt"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/btcsuite/btcd/btcec/v2"
+)
+
+// Opts contains all parameters needed to construct a VHTLC tapscript tree.
+// When NonInteractiveClaim is non-nil, a 7th covenant leaf is added that
+// allows a solver bot to claim on the receiver's behalf.
+type Opts struct {
+	Sender                               *btcec.PublicKey
+	Receiver                             *btcec.PublicKey
+	Server                               *btcec.PublicKey
+	PreimageHash                         []byte
+	RefundLocktime                       arklib.AbsoluteLocktime
+	UnilateralClaimDelay                 arklib.RelativeLocktime
+	UnilateralRefundDelay                arklib.RelativeLocktime
+	UnilateralRefundWithoutReceiverDelay arklib.RelativeLocktime
+
+	// NonInteractiveClaim, when non-nil, enables a covenant claim closure
+	// that a solver bot can satisfy unilaterally with the preimage.
+	NonInteractiveClaim *NonInteractiveClaimOpts
+}
+
+func (o Opts) validate() error {
+	if o.Sender == nil {
+		return fmt.Errorf("missing sender pubkey")
+	}
+	if o.Receiver == nil {
+		return fmt.Errorf("missing receiver pubkey")
+	}
+	if o.Server == nil {
+		return fmt.Errorf("missing server pubkey")
+	}
+
+	if len(o.PreimageHash) <= 0 {
+		return fmt.Errorf("missing preimage hash")
+	}
+	if len(o.PreimageHash) != hash160Len {
+		return fmt.Errorf("preimage hash must be %d bytes", hash160Len)
+	}
+
+	if o.RefundLocktime == 0 {
+		return fmt.Errorf("refund locktime must be greater than 0")
+	}
+
+	if err := validateTimelock(o.UnilateralClaimDelay); err != nil {
+		return fmt.Errorf("invalid unilateral claim delay: %w", err)
+	}
+
+	if err := validateTimelock(o.UnilateralRefundDelay); err != nil {
+		return fmt.Errorf("invalid unilateral refund delay: %w", err)
+	}
+
+	if err := validateTimelock(o.UnilateralRefundWithoutReceiverDelay); err != nil {
+		return fmt.Errorf("invalid unilateral refund without receiver delay: %w", err)
+	}
+
+	if o.NonInteractiveClaim != nil {
+		if err := o.NonInteractiveClaim.validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o Opts) claimClosure(preimageCondition []byte) *script.ConditionMultisigClosure {
+	return &script.ConditionMultisigClosure{
+		Condition: preimageCondition,
+		MultisigClosure: script.MultisigClosure{
+			PubKeys: []*btcec.PublicKey{o.Receiver, o.Server},
+		},
+	}
+}
+
+// refundClosure = (Sender + Receiver + Server)
+func (o Opts) refundClosure() *script.MultisigClosure {
+	return &script.MultisigClosure{
+		PubKeys: []*btcec.PublicKey{o.Sender, o.Receiver, o.Server},
+	}
+}
+
+// refundWithoutReceiverClosure = (Sender + Server) at RefundLocktime
+func (o Opts) refundWithoutReceiverClosure() *script.CLTVMultisigClosure {
+	return &script.CLTVMultisigClosure{
+		MultisigClosure: script.MultisigClosure{
+			PubKeys: []*btcec.PublicKey{o.Sender, o.Server},
+		},
+		Locktime: o.RefundLocktime,
+	}
+}
+
+// unilateralClaimClosure = (Receiver + Preimage) at UnilateralClaimDelay
+func (o Opts) unilateralClaimClosure(
+	preimageCondition []byte,
+) *script.ConditionCSVMultisigClosure {
+	return &script.ConditionCSVMultisigClosure{
+		CSVMultisigClosure: script.CSVMultisigClosure{
+			MultisigClosure: script.MultisigClosure{
+				PubKeys: []*btcec.PublicKey{o.Receiver},
+			},
+			Locktime: o.UnilateralClaimDelay,
+		},
+		Condition: preimageCondition,
+	}
+}
+
+// unilateralRefundClosure = (Sender + Receiver) at UnilateralRefundDelay
+func (o Opts) unilateralRefundClosure() *script.CSVMultisigClosure {
+	return &script.CSVMultisigClosure{
+		MultisigClosure: script.MultisigClosure{
+			PubKeys: []*btcec.PublicKey{o.Sender, o.Receiver},
+		},
+		Locktime: o.UnilateralRefundDelay,
+	}
+}
+
+// unilateralRefundWithoutReceiverClosure = (Sender) at UnilateralRefundWithoutReceiverDelay
+func (o Opts) unilateralRefundWithoutReceiverClosure() *script.CSVMultisigClosure {
+	return &script.CSVMultisigClosure{
+		MultisigClosure: script.MultisigClosure{
+			PubKeys: []*btcec.PublicKey{o.Sender},
+		},
+		Locktime: o.UnilateralRefundWithoutReceiverDelay,
+	}
+}

--- a/vhtlc/utils.go
+++ b/vhtlc/utils.go
@@ -1,0 +1,165 @@
+package vhtlc
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/btcsuite/btcd/txscript"
+)
+
+func parseClaimClosure(leaf string) (*script.ConditionMultisigClosure, error) {
+	buf, err := hex.DecodeString(leaf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode claim closure: %w", err)
+	}
+	closure := script.ConditionMultisigClosure{}
+	ok, err := closure.Decode(buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse claim closure: %w", err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("invalid claim closure %s", leaf)
+	}
+	if len(closure.PubKeys) != 2 {
+		return nil, fmt.Errorf(
+			"invalid claim closure: expected 2 pubkeys, got %d", len(closure.PubKeys),
+		)
+	}
+	return &closure, nil
+}
+
+func parseRefundClosure(leaf string) (*script.MultisigClosure, error) {
+	buf, err := hex.DecodeString(leaf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode refund closure: %w", err)
+	}
+	closure := script.MultisigClosure{}
+	ok, err := closure.Decode(buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse refund closure: %w", err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("invalid refund closure %s", leaf)
+	}
+	if len(closure.PubKeys) != 3 {
+		return nil, fmt.Errorf(
+			"invalid refund closure: expected 3 pubkeys, got %d", len(closure.PubKeys),
+		)
+	}
+	return &closure, nil
+}
+
+func parseRefundWithoutReceiverClosure(leaf string) (*script.CLTVMultisigClosure, error) {
+	buf, err := hex.DecodeString(leaf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode refund without receiver closure: %w", err)
+	}
+	closure := script.CLTVMultisigClosure{}
+	ok, err := closure.Decode(buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse refund without receiver closure: %w", err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("invalid refund without receiver closure %s", leaf)
+	}
+	if len(closure.PubKeys) != 2 {
+		return nil, fmt.Errorf(
+			"invalid refund without receiver closure: expected 2 pubkeys, got %d",
+			len(closure.PubKeys),
+		)
+	}
+	return &closure, nil
+}
+
+func parseUnilateralClaimClosure(leaf string) (*script.ConditionCSVMultisigClosure, error) {
+	buf, err := hex.DecodeString(leaf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode unilateral claim closure: %w", err)
+	}
+	closure := script.ConditionCSVMultisigClosure{}
+	ok, err := closure.Decode(buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse unilateral claim closure: %w", err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("invalid unilateral claim closure")
+	}
+	if len(closure.PubKeys) != 1 {
+		return nil, fmt.Errorf(
+			"invalid unilateral claim closure: expected 1 pubkey, got %d", len(closure.PubKeys),
+		)
+	}
+	return &closure, nil
+}
+
+func parseUnilateralRefundClosure(leaf string) (*script.CSVMultisigClosure, error) {
+	buf, err := hex.DecodeString(leaf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode unilateral refund closure: %w", err)
+	}
+	closure := script.CSVMultisigClosure{}
+	ok, err := closure.Decode(buf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse unilateral refund closure: %w", err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("invalid unilateral refund closure")
+	}
+	if len(closure.PubKeys) != 2 {
+		return nil, fmt.Errorf(
+			"invalid unilateral refund closure: expected 2 pubkeys, got %d", len(closure.PubKeys),
+		)
+	}
+	return &closure, nil
+}
+
+func parseUnilateralRefundWithoutReceiverClosure(leaf string) (*script.CSVMultisigClosure, error) {
+	buf, err := hex.DecodeString(leaf)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to decode unilateral refund without receiver closure: %w", err,
+		)
+	}
+	closure := script.CSVMultisigClosure{}
+	ok, err := closure.Decode(buf)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to parse unilateral refund without receiver closure: %w", err,
+		)
+	}
+	if !ok {
+		return nil, fmt.Errorf("invalid unilateral refund without receiver closure")
+	}
+	if len(closure.PubKeys) != 1 {
+		return nil, fmt.Errorf(
+			"invalid unilateral refund without receiver closure: expected 1 pubkey, got %d",
+			len(closure.PubKeys),
+		)
+	}
+	return &closure, nil
+}
+
+func makePreimageConditionScript(preimageHash []byte) ([]byte, error) {
+	return txscript.NewScriptBuilder().
+		AddOp(txscript.OP_HASH160).
+		AddData(preimageHash).
+		AddOp(txscript.OP_EQUAL).
+		Script()
+}
+
+func validateTimelock(locktime arklib.RelativeLocktime) error {
+	if locktime.Value == 0 {
+		return fmt.Errorf("value must be greater than 0")
+	}
+	if locktime.Type == arklib.LocktimeTypeSecond {
+		if locktime.Value < minSecondsTimelock {
+			return fmt.Errorf("value in seconds must be at least %d", minSecondsTimelock)
+		}
+		if locktime.Value%secondsTimelockMultiple != 0 {
+			return fmt.Errorf("value in seconds must be a multiple of %d", secondsTimelockMultiple)
+		}
+	}
+	return nil
+}

--- a/vhtlc/vhtlc.go
+++ b/vhtlc/vhtlc.go
@@ -1,0 +1,309 @@
+package vhtlc
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/lightningnetwork/lnd/input"
+)
+
+const (
+	hash160Len              = 20
+	sha256Len               = 32
+	minSecondsTimelock      = 512
+	secondsTimelockMultiple = 512
+)
+
+// VHTLCScript represents a Virtual Hash Time-Locked Contract as a tapscript tree.
+// It contains 6 standard spending paths (collaborative + unilateral) and an
+// optional 7th non-interactive claim covenant path.
+type VHTLCScript struct {
+	script.TapscriptsVtxoScript
+
+	Sender                                 *btcec.PublicKey
+	Receiver                               *btcec.PublicKey
+	Server                                 *btcec.PublicKey
+	ClaimClosure                           *script.ConditionMultisigClosure
+	RefundClosure                          *script.MultisigClosure
+	RefundWithoutReceiverClosure           *script.CLTVMultisigClosure
+	UnilateralClaimClosure                 *script.ConditionCSVMultisigClosure
+	UnilateralRefundClosure                *script.CSVMultisigClosure
+	UnilateralRefundWithoutReceiverClosure *script.CSVMultisigClosure
+	// NonInteractiveClaimClosure is optional. nil means the leaf is not in the taptree.
+	NonInteractiveClaimClosure *script.ConditionMultisigClosure
+	// NonInteractiveClaim preserves the original opts so Opts() can roundtrip.
+	NonInteractiveClaim *NonInteractiveClaimOpts
+
+	preimageConditionScript []byte
+}
+
+// NewVHTLCScriptFromOpts creates a VHTLC VtxoScript from the given options.
+func NewVHTLCScriptFromOpts(opts Opts) (*VHTLCScript, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
+	preimageCondition, err := makePreimageConditionScript(opts.PreimageHash)
+	if err != nil {
+		return nil, err
+	}
+
+	claimClosure := opts.claimClosure(preimageCondition)
+	refundClosure := opts.refundClosure()
+	refundWithoutReceiverClosure := opts.refundWithoutReceiverClosure()
+
+	unilateralClaimClosure := opts.unilateralClaimClosure(preimageCondition)
+	unilateralRefundClosure := opts.unilateralRefundClosure()
+	unilateralRefundWithoutReceiverClosure := opts.unilateralRefundWithoutReceiverClosure()
+
+	closures := []script.Closure{
+		// Collaborative paths
+		claimClosure,
+		refundClosure,
+		refundWithoutReceiverClosure,
+		// Exit paths
+		unilateralClaimClosure,
+		unilateralRefundClosure,
+		unilateralRefundWithoutReceiverClosure,
+	}
+
+	var nicClosure *script.ConditionMultisigClosure
+	if opts.NonInteractiveClaim != nil {
+		nicClosure, err = nonInteractiveClaimClosure(
+			preimageCondition, *opts.NonInteractiveClaim, opts.Server,
+		)
+		if err != nil {
+			return nil, err
+		}
+		closures = append(closures, nicClosure)
+	}
+
+	return &VHTLCScript{
+		TapscriptsVtxoScript: script.TapscriptsVtxoScript{
+			Closures: closures,
+		},
+		Sender:                                 opts.Sender,
+		Receiver:                               opts.Receiver,
+		Server:                                 opts.Server,
+		ClaimClosure:                           claimClosure,
+		RefundClosure:                          refundClosure,
+		RefundWithoutReceiverClosure:           refundWithoutReceiverClosure,
+		UnilateralClaimClosure:                 unilateralClaimClosure,
+		UnilateralRefundClosure:                unilateralRefundClosure,
+		UnilateralRefundWithoutReceiverClosure: unilateralRefundWithoutReceiverClosure,
+		NonInteractiveClaimClosure:             nicClosure,
+		NonInteractiveClaim:                    opts.NonInteractiveClaim,
+		preimageConditionScript:                preimageCondition,
+	}, nil
+}
+
+// NewVhtlcScript reconstructs a VHTLCScript from raw tapscript leaves.
+// This is used to recover VHTLC parameters from an on-chain or indexer response.
+func NewVhtlcScript(
+	preimageHash, claimLeaf, refundLeaf, refundWithoutReceiverLeaf, unilateralClaimLeaf,
+	unilateralRefundLeaf, unilateralRefundWithoutReceiverLeaf string,
+) (*VHTLCScript, error) {
+	// Preimage hash
+	decodedPreimageHash, err := hex.DecodeString(preimageHash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode preimage hash: %w", err)
+	}
+	// If the sha256 hash is provided, convert it to hash160
+	if len(decodedPreimageHash) == sha256Len {
+		decodedPreimageHash = input.Ripemd160H(decodedPreimageHash)
+	}
+	if len(decodedPreimageHash) != hash160Len {
+		return nil, fmt.Errorf(
+			"invalid preimage hash length: expected %d, got %d",
+			hash160Len, len(decodedPreimageHash),
+		)
+	}
+	preimageCondition, err := makePreimageConditionScript(decodedPreimageHash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build condition script: %w", err)
+	}
+
+	claimClosure, err := parseClaimClosure(claimLeaf)
+	if err != nil {
+		return nil, err
+	}
+	refundClosure, err := parseRefundClosure(refundLeaf)
+	if err != nil {
+		return nil, err
+	}
+	refundWithoutReceiverClosure, err := parseRefundWithoutReceiverClosure(refundWithoutReceiverLeaf)
+	if err != nil {
+		return nil, err
+	}
+	unilateralClaimClosure, err := parseUnilateralClaimClosure(unilateralClaimLeaf)
+	if err != nil {
+		return nil, err
+	}
+	unilateralRefundClosure, err := parseUnilateralRefundClosure(unilateralRefundLeaf)
+	if err != nil {
+		return nil, err
+	}
+	unilateralRefundWithoutReceiverClosure, err := parseUnilateralRefundWithoutReceiverClosure(
+		unilateralRefundWithoutReceiverLeaf,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract keys from closures
+	receiver := unilateralClaimClosure.PubKeys[0]
+	sender := unilateralRefundWithoutReceiverClosure.PubKeys[0]
+	var server *btcec.PublicKey
+	for _, pk := range claimClosure.PubKeys {
+		if pk.IsEqual(receiver) {
+			continue
+		}
+		server = pk
+	}
+
+	return &VHTLCScript{
+		TapscriptsVtxoScript: script.TapscriptsVtxoScript{
+			Closures: []script.Closure{
+				claimClosure,
+				refundClosure,
+				refundWithoutReceiverClosure,
+				unilateralClaimClosure,
+				unilateralRefundClosure,
+				unilateralRefundWithoutReceiverClosure,
+			},
+		},
+		Sender:                                 sender,
+		Receiver:                               receiver,
+		Server:                                 server,
+		ClaimClosure:                           claimClosure,
+		RefundClosure:                          refundClosure,
+		RefundWithoutReceiverClosure:           refundWithoutReceiverClosure,
+		UnilateralClaimClosure:                 unilateralClaimClosure,
+		UnilateralRefundClosure:                unilateralRefundClosure,
+		UnilateralRefundWithoutReceiverClosure: unilateralRefundWithoutReceiverClosure,
+		preimageConditionScript:                preimageCondition,
+	}, nil
+}
+
+// GetRevealedTapscripts returns all available scripts as hex-encoded strings.
+func (v *VHTLCScript) GetRevealedTapscripts() []string {
+	closures := []script.Closure{
+		v.ClaimClosure,
+		v.RefundClosure,
+		v.RefundWithoutReceiverClosure,
+		v.UnilateralClaimClosure,
+		v.UnilateralRefundClosure,
+		v.UnilateralRefundWithoutReceiverClosure,
+	}
+	if v.NonInteractiveClaimClosure != nil {
+		closures = append(closures, v.NonInteractiveClaimClosure)
+	}
+	var scripts []string
+	for _, closure := range closures {
+		if s, err := closure.Script(); err == nil {
+			scripts = append(scripts, hex.EncodeToString(s))
+		}
+	}
+	return scripts
+}
+
+// Address encodes the VHTLC as an Ark v0 address.
+func (v *VHTLCScript) Address(hrp string) (string, error) {
+	tapKey, _, err := v.TapTree()
+	if err != nil {
+		return "", err
+	}
+
+	addr := &arklib.Address{
+		HRP:        hrp,
+		Signer:     v.Server,
+		VtxoTapKey: tapKey,
+	}
+
+	return addr.EncodeV0()
+}
+
+// ClaimTapscript computes the necessary script and control block to spend the claim closure.
+func (v *VHTLCScript) ClaimTapscript() (*waddrmgr.Tapscript, error) {
+	claimScript, err := v.ClaimClosure.Script()
+	if err != nil {
+		return nil, err
+	}
+
+	_, tapTree, err := v.TapTree()
+	if err != nil {
+		return nil, err
+	}
+
+	leafProof, err := tapTree.GetTaprootMerkleProof(
+		txscript.NewBaseTapLeaf(claimScript).TapHash(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	ctrlBlock, err := txscript.ParseControlBlock(leafProof.ControlBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	return &waddrmgr.Tapscript{
+		RevealedScript: leafProof.Script,
+		ControlBlock:   ctrlBlock,
+	}, nil
+}
+
+// RefundTapscript computes the necessary script and control block to spend the refund closure.
+func (v *VHTLCScript) RefundTapscript(withReceiver bool) (*waddrmgr.Tapscript, error) {
+	var refundClosure script.Closure
+	refundClosure = v.RefundWithoutReceiverClosure
+	if withReceiver {
+		refundClosure = v.RefundClosure
+	}
+	refundScript, err := refundClosure.Script()
+	if err != nil {
+		return nil, err
+	}
+
+	_, tapTree, err := v.TapTree()
+	if err != nil {
+		return nil, err
+	}
+
+	refundLeafProof, err := tapTree.GetTaprootMerkleProof(
+		txscript.NewBaseTapLeaf(refundScript).TapHash(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	ctrlBlock, err := txscript.ParseControlBlock(refundLeafProof.ControlBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	return &waddrmgr.Tapscript{
+		RevealedScript: refundLeafProof.Script,
+		ControlBlock:   ctrlBlock,
+	}, nil
+}
+
+// Opts returns the options that were used to build this script.
+func (v *VHTLCScript) Opts() Opts {
+	return Opts{
+		Sender:                               v.Sender,
+		Receiver:                             v.Receiver,
+		Server:                               v.Server,
+		PreimageHash:                         v.preimageConditionScript[2 : 2+hash160Len],
+		RefundLocktime:                       v.RefundWithoutReceiverClosure.Locktime,
+		UnilateralClaimDelay:                 v.UnilateralClaimClosure.Locktime,
+		UnilateralRefundDelay:                v.UnilateralRefundClosure.Locktime,
+		UnilateralRefundWithoutReceiverDelay: v.UnilateralRefundWithoutReceiverClosure.Locktime,
+		NonInteractiveClaim:                  v.NonInteractiveClaim,
+	}
+}

--- a/vhtlc/vhtlc.go
+++ b/vhtlc/vhtlc.go
@@ -136,7 +136,9 @@ func NewVhtlcScript(
 	if err != nil {
 		return nil, err
 	}
-	refundWithoutReceiverClosure, err := parseRefundWithoutReceiverClosure(refundWithoutReceiverLeaf)
+	refundWithoutReceiverClosure, err := parseRefundWithoutReceiverClosure(
+		refundWithoutReceiverLeaf,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet_opts_test.go
+++ b/wallet_opts_test.go
@@ -199,8 +199,9 @@ func TestWalletOptions(t *testing.T) {
 // zero-value stubs since these tests never invoke the methods.
 type mockHandler struct{ typ types.ContractType }
 
+func (h *mockHandler) Derivable() bool { return true }
 func (h *mockHandler) NewContract(
-	_ context.Context, k identity.KeyRef,
+	_ context.Context, k identity.KeyRef, _ any,
 ) (*types.Contract, error) {
 	s := sha256.Sum256([]byte(string(h.typ) + ":" + k.Id))
 	return &types.Contract{


### PR DESCRIPTION
Add support for non-derivable contract(that cant be derived without external state) types to the go-sdk contract manager, with VHTLC as the first implementation.                                                                      
                                                                                                                                                                                            
  ### Contract Manager Changes                                                                                                                                                              
  - Add `Derivable() bool` to the `Handler` interface — non-derivable handlers (VHTLC, delegate, covenant) are skipped by `ScanContracts`
  - Add `WithParams(params any)` contract option — passes handler-specific typed parameters through `Manager.NewContract`                                                                   
  - `NewContract` derives the key from the wallet's identity for all types; non-derivable types require `WithParams`                                                                        
  - Skip `ValidateHandler` sanity check (NewContract with random key) for non-derivable handlers                                                                                            
                                                                                                                                                                                            
  ### VHTLC Package (`vhtlc/`)                                                                                                                                                              
  Standalone package for VHTLC script construction, ported from fulmine's `pkg/vhtlc`:                                                                                                      
  - 6 standard spending paths (claim, refund, unilateral exit variants)                                                                                                                     
  - Optional 7th non-interactive claim covenant path with arkade script enforcement                                                                                                         
  - `EnforcePayTo` arkade script builder + `IntrospectorTweakedKey` (inlined, no introspector dependency)                                                                                   
  - `NewVHTLCScriptFromOpts` / `NewVhtlcScript` (recovery from raw tapscript leaves)                                                                                                        
                                                                                                                                                                                            
  ### VHTLC Contract Handler (`contract/handlers/vhtlc/`)                                                                                                                                   
  Stateless handler — all VHTLC parameters stored in `Contract.Params`:                                                                                                                     
  - `Derivable() → false`                                                                                                                                                                   
  - `ContractParams{Opts, Network}` for typed parameter passing                                                                                                                             
  - Supports both interactive (6 leaves) and non-interactive claim (7 leaves)                                                                                                               
  - `OptsFromContract` reconstructs full `vhtlc.Opts` from persisted params                                                                                                                 
  - No role field — `ownerKey` identifies the wallet's participant key                                                                                                                      
                                                                                                                                                                                            
  ### Usage                                                                                                                                                                                 
  ```go                                                                                                                                                                                     
  manager.NewContract(ctx, vhtlcHandler.ContractTypeVHTLC,  
      contract.WithParams(&vhtlcHandler.ContractParams{                                                                                                                                     
          Opts:    opts,                                                                                                                                                                    
          Network: network,                                                                                                                                                                 
      }),                                                                                                                                                                                   
  )                                                         

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added VHTLC support with full tapscript/address handling and optional non-interactive claim flow.
  * Contract creation now accepts handler-specific parameters to support non-derivable contract types.
  * Contract scanning/derivation now skips non-derivable types and derives contracts for derivable handlers.

* **Tests**
  * Updated test harnesses, fixtures, and mocks to align with handler/derivation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->