### PR TITLE
Migrate regtest usage off nigiri (in-house Node CLI)

### DIFF
--- a/.env.regtest
+++ b/.env.regtest
@@ -1,0 +1,20 @@
+# go-sdk overrides for the embedded arkade-regtest submodule.
+#
+# regtest.mjs auto-discovers this file as ../.env.regtest (the "parent repo"
+# override — see arkade-regtest's env precedence: --env > ../.env.regtest > .env
+# > .env.defaults), so `node regtest/regtest.mjs start` picks it up with no flag.
+
+# Bring up ONLY the base layer (Bitcoin Core + nbxplorer + Fulcrum + mempool).
+# The SDK's own test/docker/docker-compose.yml builds and runs arkd + arkd-wallet
+# from source on top of this layer and reuses the base nbxplorer, so starting
+# arkade-regtest's `ark` profile would collide on the `nbxplorer` container name
+# (and run a redundant arkd).
+REGTEST_PROFILES=base
+
+# The SDK's arkd uses block-denominated locktimes (ARKD_VTXO_TREE_EXPIRY=20 and
+# the exit delays are all < 512, so arkd reads them as blocks, not seconds), and
+# expiry/sweeps fire when the chain tip reaches the target height. Disable the
+# background auto-miner so it can't advance the tip and fire sweeps mid-test —
+# all mining is explicit (the start bootstrap, plus the tests' faucet /
+# generateBlocks helpers).
+AUTOMINE_INTERVAL=0

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -30,7 +30,11 @@ jobs:
       - run: go mod tidy
 
       - name: Start arkade-regtest base stack
-        run: node regtest/regtest.mjs start --env regtest/.env.regtest
+        # Profile + auto-miner config come from the repo-root .env.regtest, which
+        # regtest.mjs auto-discovers as ../.env.regtest (REGTEST_PROFILES=base,
+        # AUTOMINE_INTERVAL=0). The SDK's own arkd/arkd-wallet are built on top by
+        # `make regtest`, so only the base layer is started here.
+        run: node regtest/regtest.mjs start
 
       - name: Run regtest environment
         run: make regtest
@@ -40,4 +44,4 @@ jobs:
 
       - name: Tear down arkade-regtest base stack
         if: always()
-        run: node regtest/regtest.mjs clean --env regtest/.env.regtest
+        run: node regtest/regtest.mjs clean

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -14,19 +14,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version: '1.26.3'
-      
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - run: go mod tidy
-      
-      - name: Run Nigiri
-        uses: vulpemventures/nigiri-github-action@v1
-      
+
+      - name: Start arkade-regtest base stack
+        run: node regtest/regtest.mjs start --env regtest/.env.regtest
+
       - name: Run regtest environment
         run: make regtest
 
       - name: Run tests
         run: make integrationtest
+
+      - name: Tear down arkade-regtest base stack
+        if: always()
+        run: node regtest/regtest.mjs clean --env regtest/.env.regtest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "regtest"]
 	path = regtest
 	url = https://github.com/ArkLabsHQ/arkade-regtest.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "regtest"]
+	path = regtest
+	url = https://github.com/ArkLabsHQ/arkade-regtest.git

--- a/README.md
+++ b/README.md
@@ -495,12 +495,17 @@ See the [pkg.go.dev documentation](https://pkg.go.dev/github.com/arkade-os/go-sd
 
 ### Testing
 
-Run integration tests ([start nigiri](https://github.com/arkade-os/arkd/blob/e33bee6196586b5f4d6ed57abe071458f49ed7ed/README.md?plain=1#L263) if needed first):
+Run integration tests. First start the [arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest)
+base stack (Bitcoin Core + Fulcrum + mempool), which provides the `bitcoin` and
+`mempool_web` containers and the `arkade-regtest` Docker network that the SDK's
+own arkd compose (`test/docker/docker-compose.yml`) layers on top of:
 
 ```sh
-make regtest
+node regtest/regtest.mjs start   # start the in-house regtest stack (Node >= 18)
+make regtest                     # build + start arkd/arkd-wallet/nbxplorer on the arkade-regtest network
 make integrationtest
-make regtestdown
+make regtestdown                 # stop the SDK arkd compose
+node regtest/regtest.mjs clean   # tear down the arkade-regtest stack
 ```
 
 ## Full Example

--- a/README.md
+++ b/README.md
@@ -495,14 +495,18 @@ See the [pkg.go.dev documentation](https://pkg.go.dev/github.com/arkade-os/go-sd
 
 ### Testing
 
-Run integration tests. First start the [arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest)
-base stack (Bitcoin Core + Fulcrum + mempool), which provides the `bitcoin` and
-`mempool_web` containers and the `arkade-regtest` Docker network that the SDK's
-own arkd compose (`test/docker/docker-compose.yml`) layers on top of:
+Run integration tests. The regtest harness is the [arkade-regtest](https://github.com/ArkLabsHQ/arkade-regtest)
+submodule (vendored at `regtest/`); init it once with `git submodule update --init`.
+First start arkade-regtest's **base** layer (Bitcoin Core + nbxplorer + Fulcrum +
+mempool), which provides the `bitcoin`, `nbxplorer` and `mempool_web` containers and
+the `arkade-regtest` Docker network that the SDK's own arkd compose
+(`test/docker/docker-compose.yml`) layers on top of. The repo-root `.env.regtest`
+(auto-discovered by `regtest.mjs`) pins it to the `base` profile and disables the
+background auto-miner, so the bare `start` command brings up only the base layer:
 
 ```sh
-node regtest/regtest.mjs start   # start the in-house regtest stack (Node >= 18)
-make regtest                     # build + start arkd/arkd-wallet/nbxplorer on the arkade-regtest network
+node regtest/regtest.mjs start   # start the arkade-regtest base layer (Node >= 18)
+make regtest                     # build + start the SDK's arkd/arkd-wallet on the arkade-regtest network
 make integrationtest
 make regtestdown                 # stop the SDK arkd compose
 node regtest/regtest.mjs clean   # tear down the arkade-regtest stack

--- a/explorer.go
+++ b/explorer.go
@@ -1,0 +1,41 @@
+package arksdk
+
+import (
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/client-lib/explorer"
+	mempoolexplorer "github.com/arkade-os/arkd/pkg/client-lib/explorer/mempool"
+)
+
+// regtestFeeRate is the fee rate (sat/vB) used on regtest. The mempool explorer
+// derives its fee rate from the esplora `GET /fee-estimates` endpoint, which the
+// local regtest stack (Fulcrum + mempool) does not serve — mempool only exposes
+// `GET /api/v1/fees/recommended`. The regtest bitcoin node runs with
+// minrelaytxfee=0, so a nominal 1 sat/vB is always sufficient.
+const regtestFeeRate = 1.0
+
+// regtestExplorer wraps a mempool explorer so that GetFeeRate returns a static
+// value on regtest, where /fee-estimates is unavailable. Every other method is
+// inherited unchanged from the embedded explorer.
+type regtestExplorer struct {
+	explorer.Explorer
+}
+
+func (regtestExplorer) GetFeeRate() (float64, error) {
+	return regtestFeeRate, nil
+}
+
+// newExplorer builds a mempool explorer for the given network, transparently
+// substituting a static fee rate on regtest (see regtestExplorer) so the SDK
+// matches the endpoints the local regtest stack actually serves.
+func newExplorer(
+	url string, network arklib.Network, opts ...mempoolexplorer.Option,
+) (explorer.Explorer, error) {
+	svc, err := mempoolexplorer.NewExplorer(url, network, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if network.Name == arklib.BitcoinRegTest.Name {
+		return regtestExplorer{svc}, nil
+	}
+	return svc, nil
+}

--- a/init.go
+++ b/init.go
@@ -19,7 +19,7 @@ import (
 var (
 	defaultExplorerUrl = map[string]string{
 		arklib.Bitcoin.Name:          "https://mempool.space/api",
-		arklib.BitcoinRegTest.Name:   "http://127.0.0.1:3000",
+		arklib.BitcoinRegTest.Name:   "http://127.0.0.1:3000/api",
 		arklib.BitcoinTestNet.Name:   "https://mempool.space/testnet/api",
 		arklib.BitcoinSigNet.Name:    "https://mempool.space/signet/api",
 		arklib.BitcoinMutinyNet.Name: "https://mutinynet.com/api",

--- a/init.go
+++ b/init.go
@@ -59,9 +59,7 @@ func (w *wallet) Init(
 	if info.Network == arklib.BitcoinRegTest.Name {
 		explorerOpts = append(explorerOpts, mempoolexplorer.WithPollInterval(2*time.Second))
 	}
-	explorer, err := mempoolexplorer.NewExplorer(
-		explorerUrl, network, explorerOpts...,
-	)
+	explorer, err := newExplorer(explorerUrl, network, explorerOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to init explorer: %v", err)
 	}

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -1,59 +1,16 @@
+# Bitcoin Core, nbxplorer, Fulcrum and the mempool/Esplora explorer all come from
+# the arkade-regtest base stack (compose project `arkade-regtest`, started with
+# `node regtest/regtest.mjs start`). This compose only adds the SDK's own arkd and
+# arkd-wallet — built from source — and reaches the base stack's `nbxplorer`,
+# `bitcoin` and `mempool_web` containers by name over the shared
+# `arkade-regtest_default` network (see the `networks` block below).
 services:
-    pgnbxplorer:
-        restart: unless-stopped
-        image: postgres:16
-        container_name: pgnbxplorer
-        ports:
-            - 5432:5432
-        environment:
-            - POSTGRES_HOST_AUTH_METHOD=trust
-        volumes:
-            - type: tmpfs
-              target: /var/lib/postgresql/data
-        healthcheck:
-            test:
-                [
-                    "CMD-SHELL",
-                    "pg_isready -U postgres -d nbxplorer -h 127.0.0.1 -p 5432",
-                ]
-            interval: 2s
-            timeout: 2s
-            retries: 30
-    nbxplorer:
-        restart: unless-stopped
-        container_name: nbxplorer
-        ports:
-            - 32838:32838
-        image: nicolasdorier/nbxplorer:2.6.7
-        environment:
-            - NBXPLORER_NETWORK=regtest
-            - NBXPLORER_CHAINS=btc
-            - NBXPLORER_BTCRPCURL=http://bitcoin:18443
-            - NBXPLORER_BTCNODEENDPOINT=bitcoin:18444
-            - NBXPLORER_BTCRPCUSER=admin1
-            - NBXPLORER_BTCRPCPASSWORD=123
-            - NBXPLORER_VERBOSE=1
-            - NBXPLORER_BIND=0.0.0.0:32838
-            - NBXPLORER_TRIMEVENTS=10000
-            - NBXPLORER_SIGNALFILESDIR=/datadir
-            - NBXPLORER_POSTGRES=User ID=postgres;Host=pgnbxplorer;Port=5432;Application Name=nbxplorer;MaxPoolSize=20;Database=nbxplorer
-            - NBXPLORER_EXPOSERPC=1
-            - NBXPLORER_NOAUTH=1
-        volumes:
-            - type: tmpfs
-              target: /datadir
-        depends_on:
-            pgnbxplorer:
-                condition: service_healthy
-
     arkd-wallet:
         restart: unless-stopped
         build:
             context: .
             dockerfile: wallet.Dockerfile
         container_name: arkd-wallet
-        depends_on:
-            - nbxplorer
         ports:
             - "6060:6060"
         environment:

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -84,7 +84,7 @@ services:
             - ARKD_BOARDING_EXIT_DELAY=30
             - ARKD_CHECKPOINT_EXIT_DELAY=10
             - ARKD_WALLET_ADDR=arkd-wallet:6060
-            - ARKD_ESPLORA_URL=http://chopsticks:3000
+            - ARKD_ESPLORA_URL=http://mempool_web/api
             - ARKD_VTXO_MIN_AMOUNT=1
             - ARKD_LIVE_STORE_TYPE=inmemory
             - ARKD_EVENT_DB_TYPE=badger
@@ -96,5 +96,5 @@ services:
 
 networks:
     default:
-        name: nigiri
+        name: arkade-regtest
         external: true

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -38,7 +38,15 @@ services:
             - ARKD_VTXO_TREE_EXPIRY=20
             - ARKD_PUBLIC_UNILATERAL_EXIT_DELAY=10
             - ARKD_UNILATERAL_EXIT_DELAY=10
-            - ARKD_BOARDING_EXIT_DELAY=30
+            # Block-denominated (< 512). arkd's boarding-input pre-check converts
+            # this to wall-clock seconds at ark-lib's SECONDS_PER_BLOCK = 1, so the
+            # value is effectively the number of *seconds* a boarding UTXO stays
+            # settle-able after it confirms. 30 was tuned for nigiri; the slower
+            # mempool-based base stack needs a wider window for fund -> detect ->
+            # settle to finish in time (otherwise arkd rejects the input as
+            # "expired" and the SDK reports the UTXO as spendable, not locked).
+            # 480 stays < 512 (block type) and no test exits/expires boarding.
+            - ARKD_BOARDING_EXIT_DELAY=480
             - ARKD_CHECKPOINT_EXIT_DELAY=10
             - ARKD_WALLET_ADDR=arkd-wallet:6060
             - ARKD_ESPLORA_URL=http://mempool_web/api

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         container_name: nbxplorer
         ports:
             - 32838:32838
-        image: nicolasdorier/nbxplorer:2.5.30
+        image: nicolasdorier/nbxplorer:2.6.7
         environment:
             - NBXPLORER_NETWORK=regtest
             - NBXPLORER_CHAINS=btc

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -96,5 +96,7 @@ services:
 
 networks:
     default:
-        name: arkade-regtest
+        # The arkade-regtest base stack (compose project `arkade-regtest`) creates
+        # its default network as `arkade-regtest_default`.
+        name: arkade-regtest_default
         external: true

--- a/test/docker/setup.go
+++ b/test/docker/setup.go
@@ -154,7 +154,7 @@ func refill(httpClient *http.Client) error {
 		}
 
 		for range int(delta) {
-			if _, err := runCommand("nigiri", "faucet", address.Address); err != nil {
+			if err := faucet(address.Address, 1); err != nil {
 				return err
 			}
 		}
@@ -234,4 +234,26 @@ func runCommand(name string, arg ...string) (string, error) {
 func newCommand(name string, arg ...string) *exec.Cmd {
 	cmd := exec.Command(name, arg...)
 	return cmd
+}
+
+// bitcoinCli runs bitcoin-cli inside the regtest "bitcoin" container provided by
+// the arkade-regtest stack (RPC user admin1 / password 123). This replaces the
+// old `nigiri rpc` passthrough now that nigiri is no longer used.
+func bitcoinCli(args ...string) (string, error) {
+	full := append([]string{
+		"exec", "bitcoin",
+		"bitcoin-cli", "-regtest", "-rpcuser=admin1", "-rpcpassword=123",
+	}, args...)
+	return runCommand("docker", full...)
+}
+
+// faucet sends amountBtc from the node wallet to address and mines one block so
+// the send confirms immediately — mirroring the `regtest.mjs faucet --confirm`
+// behavior (the new stack does not auto-mine on every faucet call).
+func faucet(address string, amountBtc float64) error {
+	if _, err := bitcoinCli("sendtoaddress", address, fmt.Sprintf("%.8f", amountBtc)); err != nil {
+		return err
+	}
+	_, err := bitcoinCli("-generate", "1")
+	return err
 }

--- a/test/e2e/rbf_test.go
+++ b/test/e2e/rbf_test.go
@@ -32,15 +32,15 @@ func TestSettleAfterRBFBumpFee(t *testing.T) {
 
 	// Create a dedicated Bitcoin Core wallet for RBF testing with low fee rate.
 	walletName := fmt.Sprintf("rbftest_%d", time.Now().UnixNano())
-	_, err = runCommand("nigiri", "rpc", "createwallet", walletName)
+	_, err = bitcoinCli(t, "createwallet", walletName)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_, _ = runCommand("nigiri", "rpc", "unloadwallet", walletName)
+		_, _ = bitcoinCli(t, "unloadwallet", walletName)
 	})
 
 	rpc := func(args ...string) (string, error) {
-		fullArgs := append([]string{"rpc", fmt.Sprintf("-rpcwallet=%s", walletName)}, args...)
-		return runCommand("nigiri", fullArgs...)
+		fullArgs := append([]string{fmt.Sprintf("-rpcwallet=%s", walletName)}, args...)
+		return bitcoinCli(t, fullArgs...)
 	}
 
 	// Fund the test wallet.
@@ -74,7 +74,7 @@ func TestSettleAfterRBFBumpFee(t *testing.T) {
 		var bumpResp struct {
 			Txid string `json:"txid"`
 		}
-		// Strip ANSI escape codes that nigiri injects via terminal coloring.
+		// Defensively strip any ANSI escape codes before parsing JSON.
 		cleanBump := ansiRe.ReplaceAllString(strings.TrimSpace(bumpOut), "")
 		require.NoError(t, json.Unmarshal([]byte(cleanBump), &bumpResp))
 

--- a/test/e2e/rbf_test.go
+++ b/test/e2e/rbf_test.go
@@ -51,24 +51,26 @@ func TestSettleAfterRBFBumpFee(t *testing.T) {
 	faucetOnchain(t, fundAddr, 1)
 	generateBlocks(t, 1)
 
-	// Set a low fee rate so bumpfee has room to increase.
-	_, err = rpc("settxfee", "0.00001000")
-	require.NoError(t, err)
-
 	// Send 5 boarding transactions, each RBF-bumped and mined individually.
 	// Mining after each bump ensures the wallet has a confirmed UTXO for the
 	// next send (otherwise sendtoaddress fails due to insufficient funds).
 	ansiRe := regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	const numBoardingTxs = 5
 	for range numBoardingTxs {
+		// Send at an explicit low fee rate (1 sat/vB) so bumpfee has room to
+		// increase. Bitcoin Core 31 removed the settxfee RPC, so the fee rate is
+		// set per-transaction via the fee_rate named argument.
 		txidOut, err := rpc("-named", "sendtoaddress",
-			fmt.Sprintf("address=%s", boardingAddr), "amount=0.001", "replaceable=true",
+			fmt.Sprintf("address=%s", boardingAddr),
+			"amount=0.001", "replaceable=true", "fee_rate=1",
 		)
 		require.NoError(t, err)
 		origTxid := strings.TrimSpace(txidOut)
 
-		// Bump the fee — this creates a replacement tx that may reorder outputs.
-		bumpOut, err := rpc("bumpfee", origTxid)
+		// Bump to an explicit higher rate (10 sat/vB): creates a replacement tx
+		// that may reorder outputs. An explicit fee_rate is required because
+		// regtest has no fee estimation (settxfee was removed in Core 31).
+		bumpOut, err := rpc("bumpfee", origTxid, `{"fee_rate": 10}`)
 		require.NoError(t, err)
 
 		var bumpResp struct {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -21,7 +21,7 @@ import (
 const (
 	password    = "secret"
 	serverUrl   = "127.0.0.1:7070"
-	explorerUrl = "http://127.0.0.1:3000"
+	explorerUrl = "http://127.0.0.1:3000/api"
 )
 
 func setupClient(t *testing.T, seed string, opts ...sdk.WalletOption) sdk.Wallet {
@@ -46,8 +46,12 @@ func setupClient(t *testing.T, seed string, opts ...sdk.WalletOption) sdk.Wallet
 }
 
 func faucetOnchain(t *testing.T, address string, amount float64) {
-	_, err := runCommand("nigiri", "faucet", address, fmt.Sprintf("%.8f", amount))
+	// Send from the node wallet and mine one block to confirm — mirrors the
+	// `regtest.mjs faucet --confirm` behavior (the arkade-regtest stack does not
+	// auto-mine on every faucet call).
+	_, err := bitcoinCli(t, "sendtoaddress", address, fmt.Sprintf("%.8f", amount))
 	require.NoError(t, err)
+	generateBlocks(t, 1)
 }
 
 func faucetOffchain(
@@ -173,6 +177,18 @@ func newCommand(name string, arg ...string) *exec.Cmd {
 }
 
 func generateBlocks(t *testing.T, n int) {
-	_, err := runCommand("nigiri", "rpc", "--generate", fmt.Sprintf("%d", n))
+	_, err := bitcoinCli(t, "-generate", fmt.Sprintf("%d", n))
 	require.NoError(t, err)
+}
+
+// bitcoinCli runs bitcoin-cli inside the regtest "bitcoin" container provided by
+// the arkade-regtest stack (RPC user admin1 / password 123). This replaces the
+// old `nigiri rpc` passthrough now that nigiri is no longer used.
+func bitcoinCli(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	full := append([]string{
+		"exec", "bitcoin",
+		"bitcoin-cli", "-regtest", "-rpcuser=admin1", "-rpcpassword=123",
+	}, args...)
+	return runCommand("docker", full...)
 }

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -49,7 +49,11 @@ func faucetOnchain(t *testing.T, address string, amount float64) {
 	// Send from the node wallet and mine one block to confirm — mirrors the
 	// `regtest.mjs faucet --confirm` behavior (the arkade-regtest stack does not
 	// auto-mine on every faucet call).
-	_, err := bitcoinCli(t, "sendtoaddress", address, fmt.Sprintf("%.8f", amount))
+	//
+	// Target the node's "default" wallet explicitly: the base stack's bootstrap
+	// loads a "default" wallet, and tests like rbf_test.go load a second wallet,
+	// after which a bare wallet RPC is ambiguous ("Multiple wallets are loaded").
+	_, err := bitcoinCli(t, "-rpcwallet=default", "sendtoaddress", address, fmt.Sprintf("%.8f", amount))
 	require.NoError(t, err)
 	generateBlocks(t, 1)
 }
@@ -177,7 +181,10 @@ func newCommand(name string, arg ...string) *exec.Cmd {
 }
 
 func generateBlocks(t *testing.T, n int) {
-	_, err := bitcoinCli(t, "-generate", fmt.Sprintf("%d", n))
+	// `-generate` derives a coinbase address from a loaded wallet; pin it to the
+	// node's "default" wallet so it stays unambiguous when a test (e.g. rbf_test.go)
+	// has a second wallet loaded.
+	_, err := bitcoinCli(t, "-rpcwallet=default", "-generate", fmt.Sprintf("%d", n))
 	require.NoError(t, err)
 }
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -53,7 +53,8 @@ func faucetOnchain(t *testing.T, address string, amount float64) {
 	// Target the node's "default" wallet explicitly: the base stack's bootstrap
 	// loads a "default" wallet, and tests like rbf_test.go load a second wallet,
 	// after which a bare wallet RPC is ambiguous ("Multiple wallets are loaded").
-	_, err := bitcoinCli(t, "-rpcwallet=default", "sendtoaddress", address, fmt.Sprintf("%.8f", amount))
+	amountBtc := fmt.Sprintf("%.8f", amount)
+	_, err := bitcoinCli(t, "-rpcwallet=default", "sendtoaddress", address, amountBtc)
 	require.NoError(t, err)
 	generateBlocks(t, 1)
 }

--- a/wallet.go
+++ b/wallet.go
@@ -228,9 +228,7 @@ func LoadWallet(datadir string, opts ...WalletOption) (Wallet, error) {
 		if cfgData.Network.Name == arklib.BitcoinRegTest.Name {
 			explorerOpts = append(explorerOpts, mempoolexplorer.WithPollInterval(2*time.Second))
 		}
-		explorerSvc, err = mempoolexplorer.NewExplorer(
-			explorerUrl, cfgData.Network, explorerOpts...,
-		)
+		explorerSvc, err = newExplorer(explorerUrl, cfgData.Network, explorerOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to init explorer: %v", err)
 		}

--- a/wallet_test.go
+++ b/wallet_test.go
@@ -208,7 +208,7 @@ func seedIdentity(t *testing.T, datadir string) {
 		SignerPubKey:  randomKey.PubKey(),
 		ForfeitPubKey: randomKey.PubKey(),
 		Network:       arklib.BitcoinRegTest,
-		ExplorerURL:   "http://127.0.0.1:3000",
+		ExplorerURL:   "http://127.0.0.1:3000/api",
 	})
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

Migrates the go-sdk integration-test regtest harness off **nigiri** onto the in-house
**arkade-regtest** Node CLI stack (`ArkLabsHQ/arkade-regtest`, PR #27 / branch `denigiri-regtest`).

- **Esplora URLs** gain the mempool `/api` suffix:
  - `init.go` regtest default `http://127.0.0.1:3000` → `http://127.0.0.1:3000/api`
  - `test/e2e/utils_test.go` `explorerUrl`, and the `wallet_test.go` config-store test, likewise.
  - `test/docker/docker-compose.yml` `ARKD_ESPLORA_URL=http://chopsticks:3000` → `http://mempool_web/api`
    (in-network name change).
- **Docker network**: `test/docker/docker-compose.yml` joins the external **`arkade-regtest`**
  network instead of `nigiri`.
- **CLI shell-outs**: the `nigiri` binary no longer exists, so `nigiri faucet` / `nigiri rpc …` /
  `nigiri rpc --generate` are replaced by `docker exec bitcoin bitcoin-cli -regtest -rpcuser=admin1
  -rpcpassword=123 …` — the `bitcoin` container the new stack exposes. New `bitcoinCli` + `faucet`
  helpers added to `test/docker/setup.go` and `test/e2e/utils_test.go`; `test/e2e/rbf_test.go` raw
  RPC (createwallet/unloadwallet/`-rpcwallet`/settxfee/sendtoaddress/bumpfee) routed through them.
- **CI** (`.github/workflows/integration.yaml`): drop the `vulpemventures/nigiri-github-action`;
  add `actions/setup-node`, `actions/checkout` with `submodules: recursive`, and start/clean the
  arkade-regtest stack via `node regtest/regtest.mjs start|clean`.
- **README** testing section updated to the two-step start (node CLI base stack + `make regtest`).

`gofmt` and `go vet ./test/e2e` are clean; `go build ./test/docker` succeeds. Full integration
tests cannot run until arkade-regtest#27 merges (see below) — no green integration run is claimed.

## ⚠ Behavioral change — mining

- Old nigiri auto-mined and `nigiri faucet` confirmed immediately.
- The new stack's `faucet` spends from the Bitcoin Core node wallet and does **NOT** mine by default;
  a background auto-miner mines 1 block every `AUTOMINE_INTERVAL` seconds (default 600; `0` disables).
- Accordingly, every faucet helper in this PR (`faucet` in `setup.go`, `faucetOnchain` in
  `utils_test.go`) now **mines 1 block right after the send** to confirm — matching the
  `regtest.mjs faucet --confirm` semantics. Any test that faucets then waits for a confirmation
  relies on this.

## Consumption pattern (important — diverges from the submodule recipe)

go-sdk does **not** embed `arkade-regtest` as a git submodule. Its `make regtest` runs its **own**
`test/docker/docker-compose.yml`, which builds arkd / arkd-wallet from local `server.Dockerfile` /
`wallet.Dockerfile` and previously layered them onto **nigiri's** base layer (Bitcoin Core +
chopsticks esplora + the external `nigiri` network) while shelling out to the `nigiri` CLI.

This PR retargets that base layer to the arkade-regtest stack (`bitcoin` / `mempool_web` containers,
`arkade-regtest` network). The CLI/URL/network changes above are the unambiguous part. The wiring of
how the stack is *obtained and started* is the open question below — done conservatively rather than
guessed.

## Verify after arkade-regtest#27 merges

- [ ] Add `arkade-regtest` as a git submodule at `regtest/` (e.g. `git submodule add
      https://github.com/ArkLabsHQ/arkade-regtest regtest`), pinned to **`master`** once #27 is
      merged there — **not** to the unmerged `denigiri-regtest` branch. (No submodule SHA is bumped
      in this PR because none exists yet.)
- [ ] Confirm `node regtest/regtest.mjs start` brings up the `bitcoin` and `mempool_web` containers
      and the `arkade-regtest` Docker network expected by `test/docker/docker-compose.yml`.
- [ ] Run `make regtest && make integrationtest` locally end-to-end and confirm green.
- [ ] Re-run the integration CI job and confirm green.

## Open questions / manual follow-ups (please review)

1. **How does the regtest stack get into the repo?** This PR assumes a `regtest/regtest.mjs`
   submodule will be added (per the checklist). The CI steps and README reference `regtest/regtest.mjs`
   on that assumption. If maintainers prefer to invoke arkade-regtest some other way (vendored copy,
   external clone in CI), the `node regtest/regtest.mjs …` invocations in CI/README should be adjusted.
2. **Overlapping services.** The arkade-regtest base/ark stack already ships its own `nbxplorer`,
   `arkd`, and `arkd-wallet` containers. go-sdk's `test/docker/docker-compose.yml` builds its **own**
   arkd from source and runs its own `nbxplorer` — so it should start only the **base** profile of
   arkade-regtest (Bitcoin Core + Fulcrum + mempool), not the `ark` profile, to avoid container-name
   collisions (`nbxplorer`, `arkd`, `arkd-wallet`). The exact `REGTEST_PROFILES`/start invocation to
   use here needs a maintainer decision; left unset in this PR.
3. **Multi-wallet RPC ambiguity in `rbf_test.go`.** With the dedicated `rbftest_*` wallet loaded
   alongside the node wallet, bare (non-`-rpcwallet`) calls such as `faucetOnchain`/`generateBlocks`
   may be ambiguous to bitcoind. This matched nigiri's prior behavior, so it is left unchanged here,
   but should be verified once the stack runs.
4. **No `.env.regtest` in go-sdk.** The brief's env-var removals (`NIGIRI_*`, `BITCOIN_LOW_FEE`,
   `ARK_CONTAINER`) do not apply — go-sdk has no such override file. CI references
   `regtest/.env.regtest`, which will come from the submodule once added.

Blocked by ArkLabsHQ/arkade-regtest#27
