### PR TITLE
Support combined script and asset filters for VTXO queries

### DIFF
--- a/funding_opts_test.go
+++ b/funding_opts_test.go
@@ -40,6 +40,24 @@ func TestListVtxosOptions(t *testing.T) {
 		require.Equal(t, "usdt", o.assetID)
 	})
 
+	t.Run("WithScript rejects empty", func(t *testing.T) {
+		o := defaultListVtxosOpts()
+		require.ErrorIs(t, WithScript("")(o), ErrEmptyScript)
+		require.NoError(t, WithScript("deadbeef")(o))
+		require.Equal(t, "deadbeef", o.script)
+	})
+
+	t.Run("WithScript and WithAssetID combine on the same options", func(t *testing.T) {
+		// Stablecoin payment tracking: filter a specific address' script and a
+		// specific asset at the same time. The two options are independent and
+		// must both be retained.
+		o := defaultListVtxosOpts()
+		require.NoError(t, WithScript("deadbeef")(o))
+		require.NoError(t, WithAssetID("usdt")(o))
+		require.Equal(t, "deadbeef", o.script)
+		require.Equal(t, "usdt", o.assetID)
+	})
+
 	t.Run("status options mutually exclusive", func(t *testing.T) {
 		o := defaultListVtxosOpts()
 		require.NoError(t, WithSpendableOnly()(o))
@@ -110,6 +128,26 @@ func TestFilterHash(t *testing.T) {
 		a.assetID = "usdt"
 		b := defaultListVtxosOpts()
 		b.assetID = "btc"
+		require.NotEqual(t, filterHash(a), filterHash(b))
+	})
+
+	t.Run("differs by script", func(t *testing.T) {
+		a := defaultListVtxosOpts()
+		a.script = "scriptA"
+		b := defaultListVtxosOpts()
+		b.script = "scriptB"
+		require.NotEqual(t, filterHash(a), filterHash(b))
+	})
+
+	t.Run("differs when only one filter changes within a combined set", func(t *testing.T) {
+		// A cursor issued for (scriptA, usdt) must not be reusable for
+		// (scriptA, usdc): same script, different asset → different hash.
+		a := defaultListVtxosOpts()
+		a.script = "scriptA"
+		a.assetID = "usdt"
+		b := defaultListVtxosOpts()
+		b.script = "scriptA"
+		b.assetID = "usdc"
 		require.NotEqual(t, filterHash(a), filterHash(b))
 	})
 

--- a/store/vtxo_store_test.go
+++ b/store/vtxo_store_test.go
@@ -760,6 +760,102 @@ func TestVtxoStoreGetVtxos(t *testing.T) {
 				require.Empty(t, got)
 			})
 
+			t.Run("script and asset filters combine", func(t *testing.T) {
+				// Models a stablecoin payment-tracking backend recovering after
+				// a crash: at startup it calls GetVtxos filtered by BOTH the
+				// receiving address' script AND the tracked asset id, to
+				// enumerate only the payments of that asset that landed on that
+				// address. VTXOs matching only one of the two predicates (right
+				// address but wrong asset, right asset but wrong address, or
+				// bitcoin-only) must be excluded.
+				require.NoError(t, s.Clean(ctx))
+
+				const (
+					addrA = "0000000000000000000000000000000000000000000000000000000000000a11"
+					addrB = "0000000000000000000000000000000000000000000000000000000000000b22"
+				)
+				usdt := testVtxoAsset1 // the stablecoin we are tracking
+				usdc := testVtxoAsset2 // a different asset
+
+				mk := func(txid, script string, assets ...clientTypes.Asset) clientTypes.Vtxo {
+					return clientTypes.Vtxo{
+						Outpoint: clientTypes.Outpoint{Txid: txid, VOut: 0},
+						Script:   script,
+						Amount:   1000,
+						CommitmentTxids: []string{
+							"0000000000000000000000000000000000000000000000000000000000000000",
+						},
+						ExpiresAt: seed[0].ExpiresAt,
+						CreatedAt: seed[0].CreatedAt,
+						Assets:    assets,
+					}
+				}
+
+				// Two payments matching BOTH addrA and the tracked stablecoin.
+				wantA1 := mk(
+					"1111000000000000000000000000000000000000000000000000000000000001", addrA, usdt,
+				)
+				wantA2 := mk(
+					"1111000000000000000000000000000000000000000000000000000000000002", addrA, usdt,
+				)
+				// Right address, wrong asset — must be excluded.
+				addrAWrongAsset := mk(
+					"2222000000000000000000000000000000000000000000000000000000000001", addrA, usdc,
+				)
+				// Right asset, wrong address — must be excluded.
+				addrBRightAsset := mk(
+					"3333000000000000000000000000000000000000000000000000000000000001", addrB, usdt,
+				)
+				// Right address, bitcoin only (no asset) — must be excluded.
+				addrANoAsset := mk(
+					"4444000000000000000000000000000000000000000000000000000000000001", addrA,
+				)
+
+				seedVtxos(
+					t, s, wantA1, wantA2, addrAWrongAsset, addrBRightAsset, addrANoAsset,
+				)
+
+				got, _, err := s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status:  types.VtxoStatusAll,
+					Script:  addrA,
+					AssetID: usdt.AssetId,
+					Limit:   1000,
+				})
+				require.NoError(t, err)
+				require.Len(t, got, 2)
+				gotOutpoints := map[clientTypes.Outpoint]bool{}
+				for _, v := range got {
+					gotOutpoints[v.Outpoint] = true
+					require.Equal(t, addrA, v.Script)
+					hasAsset := false
+					for _, a := range v.Assets {
+						if a.AssetId == usdt.AssetId {
+							hasAsset = true
+						}
+					}
+					require.True(t, hasAsset, "returned vtxo must carry the tracked asset")
+				}
+				require.True(t, gotOutpoints[wantA1.Outpoint])
+				require.True(t, gotOutpoints[wantA2.Outpoint])
+
+				// Narrowing further to spendable only must still respect both
+				// filters: once wantA1 is spent, only wantA2 remains.
+				_, err = s.SpendVtxos(ctx, map[clientTypes.Outpoint]string{
+					wantA1.Outpoint: "spendertx",
+				}, "arktx")
+				require.NoError(t, err)
+
+				got, _, err = s.GetVtxos(ctx, types.GetVtxoFilter{
+					Status:  types.VtxoStatusSpendable,
+					Script:  addrA,
+					AssetID: usdt.AssetId,
+					Limit:   1000,
+				})
+				require.NoError(t, err)
+				require.Len(t, got, 1)
+				require.Equal(t, wantA2.Outpoint, got[0].Outpoint)
+			})
+
 			t.Run("tiebreaker on identical created_at", func(t *testing.T) {
 				// Seed N VTXOs with identical created_at and distinct
 				// (txid, vout). Page through in small pages and assert that


### PR DESCRIPTION
## Summary
This PR adds support for filtering VTXOs by both script and asset ID simultaneously, enabling use cases like stablecoin payment tracking where a backend needs to enumerate payments of a specific asset that landed on a specific address.

## Key Changes
- **VTXO Store**: Added comprehensive test case `TestVtxoStoreGetVtxos/script and asset filters combine` that validates:
  - VTXOs matching both script and asset filters are returned
  - VTXOs matching only one filter (right address/wrong asset, right asset/wrong address, or bitcoin-only) are correctly excluded
  - Combined filters work correctly with status filters (e.g., spendable-only queries respect both predicates)

- **Funding Options**: Enhanced `funding_opts_test.go` with new test coverage:
  - `WithScript` option validation (rejects empty scripts)
  - Combined `WithScript` and `WithAssetID` options work independently on the same options object
  - Filter hash computation correctly differentiates between combined filter sets (e.g., same script with different assets produces different hashes, preventing cursor reuse across different filter combinations)

## Implementation Details
The changes ensure that when both `Script` and `AssetID` filters are provided to `GetVtxos`, the query returns only VTXOs that satisfy **both** predicates. The filter hash mechanism properly accounts for combined filters, preventing cursor reuse when filter combinations change while individual components remain the same.

https://claude.ai/code/session_0176DBKMUGPEqTV81makx32j