### PR TITLE
Make refresh db interval and gap limit options non-nullable

### DIFF
--- a/test/e2e/hd_wallet_test.go
+++ b/test/e2e/hd_wallet_test.go
@@ -142,13 +142,13 @@ func TestHDWalletRecoversFundsAtRestore(t *testing.T) {
 func TestHDWalletDoesNotRecoverVtxoBeyondConfiguredGapLimit(t *testing.T) {
 	ctx := t.Context()
 
-	const gapLimit = uint32(5)
+	const gapLimit = uint32(20)
 
 	aliceClientHD := setupClient(t, "", sdk.WithGapLimit(gapLimit))
 	bobClientHD := setupClient(t, "")
 
-	addresses := make([]string, 0, 11)
-	for range 11 {
+	addresses := make([]string, 0, 31)
+	for range 31 {
 		addr, err := aliceClientHD.NewOffchainAddress(ctx)
 		require.NoError(t, err)
 		addresses = append(addresses, addr)
@@ -172,7 +172,7 @@ func TestHDWalletDoesNotRecoverVtxoBeyondConfiguredGapLimit(t *testing.T) {
 	aliceClientHD = nil
 
 	_, err = bobClientHD.SendOffChain(ctx, []clientTypes.Receiver{{
-		To:     addresses[10],
+		To:     addresses[30],
 		Amount: 16_000,
 	}})
 	require.NoError(t, err)

--- a/test/e2e/history_test.go
+++ b/test/e2e/history_test.go
@@ -14,7 +14,10 @@ func TestTransactionHistory(t *testing.T) {
 	ctx := t.Context()
 	// Make use of a long db refresh interval to avoid that background operation to mess up
 	// with this test
-	alice := setupClient(t, "", arksdk.WithoutAutoSettle(), arksdk.WithRefreshDbInterval(5*time.Minute))
+	opts := []arksdk.WalletOption{
+		arksdk.WithoutAutoSettle(), arksdk.WithRefreshDbInterval(5 * time.Minute),
+	}
+	alice := setupClient(t, "", opts...)
 
 	history, err := alice.GetTransactionHistory(ctx)
 	require.NoError(t, err)
@@ -118,7 +121,7 @@ func TestTransactionHistory(t *testing.T) {
 	requireTxEqual(t, settledBoardingTx, history[0], "")
 
 	// alice sends funds to bob
-	bob := setupClient(t, "", arksdk.WithoutAutoSettle(), arksdk.WithRefreshDbInterval(5*time.Minute))
+	bob := setupClient(t, "", opts...)
 	bobTxChan := bob.GetTransactionEventChannel(ctx)
 
 	bobOnchainAddr, err := bob.NewOnchainAddress(ctx)

--- a/test/e2e/history_test.go
+++ b/test/e2e/history_test.go
@@ -12,7 +12,9 @@ import (
 
 func TestTransactionHistory(t *testing.T) {
 	ctx := t.Context()
-	alice := setupClient(t, "", arksdk.WithoutAutoSettle())
+	// Make use of a long db refresh interval to avoid that background operation to mess up
+	// with this test
+	alice := setupClient(t, "", arksdk.WithoutAutoSettle(), arksdk.WithRefreshDbInterval(5*time.Minute))
 
 	history, err := alice.GetTransactionHistory(ctx)
 	require.NoError(t, err)
@@ -116,7 +118,7 @@ func TestTransactionHistory(t *testing.T) {
 	requireTxEqual(t, settledBoardingTx, history[0], "")
 
 	// alice sends funds to bob
-	bob := setupClient(t, "", arksdk.WithoutAutoSettle())
+	bob := setupClient(t, "", arksdk.WithoutAutoSettle(), arksdk.WithRefreshDbInterval(5*time.Minute))
 	bobTxChan := bob.GetTransactionEventChannel(ctx)
 
 	bobOnchainAddr, err := bob.NewOnchainAddress(ctx)

--- a/wallet_opts.go
+++ b/wallet_opts.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	minInterval               = 30 * time.Second
-	defaultGapLimit           = 20
+	minDbRefreshInterval      = 30 * time.Second
+	minGapLimit               = 20
 	defaultMaxMigrationInputs = 50
 )
 
@@ -32,13 +32,14 @@ func ApplyWalletOptions(opts ...WalletOption) error {
 // disables periodic refresh entirely.
 func WithRefreshDbInterval(d time.Duration) WalletOption {
 	return func(o *walletOptions) error {
-		if o.refreshDbInterval != 0 {
+		if o.refreshDbIntervalSet {
 			return fmt.Errorf("refresh db interval already set")
 		}
-		if d < minInterval {
-			return fmt.Errorf("refresh db interval must be at least %s", minInterval)
+		if d < minDbRefreshInterval {
+			return fmt.Errorf("refresh db interval must be at least %s", minDbRefreshInterval)
 		}
 		o.refreshDbInterval = d
+		o.refreshDbIntervalSet = true
 		return nil
 	}
 }
@@ -58,8 +59,8 @@ func WithGapLimit(limit uint32) WalletOption {
 		if o.hdGapLimitSet {
 			return fmt.Errorf("gap limit already set")
 		}
-		if limit == 0 {
-			return fmt.Errorf("gap limit must be greater than zero")
+		if limit < minGapLimit {
+			return fmt.Errorf("gap limit must be at least %d", minGapLimit)
 		}
 		o.hdGapLimit = limit
 		o.hdGapLimitSet = true
@@ -150,20 +151,22 @@ func applyWalletOptions(opts ...WalletOption) (*walletOptions, error) {
 }
 
 type walletOptions struct {
-	refreshDbInterval time.Duration
-	verbose           bool
-	hdGapLimit        uint32
-	hdGapLimitSet     bool
-	identity          identity.Identity
-	scheduler         scheduler.SchedulerService
-	disableAutoSettle bool
-	customHandlers    map[types.ContractType]handlers.Handler
+	refreshDbIntervalSet bool
+	refreshDbInterval    time.Duration
+	verbose              bool
+	hdGapLimit           uint32
+	hdGapLimitSet        bool
+	identity             identity.Identity
+	scheduler            scheduler.SchedulerService
+	disableAutoSettle    bool
+	customHandlers       map[types.ContractType]handlers.Handler
 }
 
-// newDefaultWalletOptions returns a zero-value walletOptions.
-// A zero refreshDbInterval disables periodic DB refresh (periodicRefreshDb exits early).
+// newDefaultWalletOptions returns a zero-value walletOptions with default hdGapLimit (20) and
+// refreshDbInterval (30s). These values cannot be zero-ed.
 func newDefaultWalletOptions() *walletOptions {
 	return &walletOptions{
-		hdGapLimit: defaultGapLimit,
+		hdGapLimit:        minGapLimit,
+		refreshDbInterval: minDbRefreshInterval,
 	}
 }

--- a/wallet_opts_test.go
+++ b/wallet_opts_test.go
@@ -40,7 +40,7 @@ func TestWalletOptions(t *testing.T) {
 			},
 			{
 				name: "WithGapLimit",
-				opts: []arksdk.WalletOption{arksdk.WithGapLimit(10)},
+				opts: []arksdk.WalletOption{arksdk.WithGapLimit(30)},
 			},
 			{
 				name: "WithIdentity",
@@ -100,13 +100,13 @@ func TestWalletOptions(t *testing.T) {
 			{
 				name:            "WithGapLimit zero",
 				opts:            []arksdk.WalletOption{arksdk.WithGapLimit(0)},
-				wantErrContains: "gap limit must be greater than zero",
+				wantErrContains: "gap limit must be at least",
 			},
 			{
 				name: "WithGapLimit twice",
 				opts: []arksdk.WalletOption{
-					arksdk.WithGapLimit(10),
-					arksdk.WithGapLimit(12),
+					arksdk.WithGapLimit(30),
+					arksdk.WithGapLimit(32),
 				},
 				wantErrContains: "gap limit already set",
 			},


### PR DESCRIPTION
This adds lower bounds to the refresh db interval (30s) and the gap limit (20) configurable values via options.

Before this, the wallet would have started by default without a periodic refresh db interval unless WithRefreshDbInterval was explicitly used, and also the gap limit for restore could have been shrunk to 1, making the restore extremely inefficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet option validation by enforcing minimum non-zero refresh intervals and HD wallet gap limits (including clearer “must be at least” errors).
  * Made repeated wallet configuration detection more reliable to prevent conflicting setups.
* **Tests**
  * Updated HD wallet and wallet option test expectations to reflect the new gap-limit behavior and default minimums.
  * Adjusted transaction history end-to-end setup to use consistent wallet options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->