### PR TITLE
Finalize pending txs on periodic db refresh

### DIFF
--- a/test/e2e/transaction_test.go
+++ b/test/e2e/transaction_test.go
@@ -559,6 +559,146 @@ func TestOffchainTx(t *testing.T) {
 			})
 		}, 30*time.Second, time.Second)
 	})
+
+	// In this test Alice submits a tx without finalizing it and, without any
+	// restart or restore, the wallet's periodic db refresh finalizes the
+	// stranded pending tx on its own.
+	t.Run("finalize pending tx (periodic refresh)", func(t *testing.T) {
+		ctx := t.Context()
+		// WithoutAutoSettle so the scheduler doesn't settle the funding vtxo out
+		// from under the pending tx during the (>= refresh-interval) wait.
+		alice := setupClient(t, "", arksdk.WithoutAutoSettle())
+
+		vtxo := faucetOffchain(t, alice, 0.00021)
+
+		txid := submitUnfinalizedArkTx(t, alice, vtxo)
+
+		// It starts out unfinalized: not yet in history.
+		time.Sleep(time.Second)
+		history, err := alice.GetTransactionHistory(ctx)
+		require.NoError(t, err)
+		require.False(t, slices.ContainsFunc(history, func(tx clientTypes.Transaction) bool {
+			return tx.TransactionKey.String() == txid
+		}))
+
+		// The periodic refresh finalizes it without a restart, so it eventually
+		// shows up in history. The window allows for a few refresh ticks.
+		require.Eventually(t, func() bool {
+			history, err := alice.GetTransactionHistory(ctx)
+			if err != nil {
+				return false
+			}
+			return slices.ContainsFunc(history, func(tx clientTypes.Transaction) bool {
+				return tx.TransactionKey.String() == txid
+			})
+		}, 90*time.Second, 2*time.Second)
+	})
+}
+
+// submitUnfinalizedArkTx builds, signs and submits an ark tx spending vtxo, but
+// deliberately does not finalize it, leaving a pending (non-finalized) tx whose
+// input the server considers spent. It returns the ark txid.
+func submitUnfinalizedArkTx(t *testing.T, alice arksdk.Wallet, vtxo clientTypes.Vtxo) string {
+	t.Helper()
+	ctx := t.Context()
+	aliceWallet := alice.Identity()
+	arkClient := alice.Client()
+	contractManager := alice.ContractManager()
+
+	aliceAddr, err := alice.NewOffchainAddress(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, aliceAddr)
+
+	decoded, err := arklib.DecodeAddressV0(aliceAddr)
+	require.NoError(t, err)
+	outScript, err := decoded.GetPkScript()
+	require.NoError(t, err)
+
+	contracts, err := contractManager.GetContracts(
+		ctx, contract.WithScripts([]string{vtxo.Script}),
+	)
+	require.NoError(t, err)
+	require.Len(t, contracts, 1)
+	ctr := contracts[0]
+
+	handler, err := contractManager.GetHandler(ctx, ctr)
+	require.NoError(t, err)
+	tapscripts, err := handler.GetTapscripts(ctr)
+	require.NoError(t, err)
+	require.NotEmpty(t, tapscripts)
+
+	serverParams, err := arkClient.GetInfo(ctx)
+	require.NoError(t, err)
+
+	vtxoScript, err := script.ParseVtxoScript(tapscripts)
+	require.NoError(t, err)
+	forfeitClosures := vtxoScript.ForfeitClosures()
+	require.Len(t, forfeitClosures, 1)
+	scriptBytes, err := forfeitClosures[0].Script()
+	require.NoError(t, err)
+
+	_, vtxoTapTree, err := vtxoScript.TapTree()
+	require.NoError(t, err)
+	merkleProof, err := vtxoTapTree.GetTaprootMerkleProof(
+		txscript.NewBaseTapLeaf(scriptBytes).TapHash(),
+	)
+	require.NoError(t, err)
+	ctrlBlock, err := txscript.ParseControlBlock(merkleProof.ControlBlock)
+	require.NoError(t, err)
+	tapscript := &waddrmgr.Tapscript{
+		ControlBlock:   ctrlBlock,
+		RevealedScript: merkleProof.Script,
+	}
+
+	checkpointTapscript, err := hex.DecodeString(serverParams.CheckpointTapscript)
+	require.NoError(t, err)
+	vtxoHash, err := chainhash.NewHashFromStr(vtxo.Txid)
+	require.NoError(t, err)
+
+	ptx, checkpointsPtx, err := offchain.BuildTxs(
+		[]offchain.VtxoInput{
+			{
+				Outpoint: &wire.OutPoint{
+					Hash:  *vtxoHash,
+					Index: vtxo.VOut,
+				},
+				Tapscript:          tapscript,
+				Amount:             int64(vtxo.Amount),
+				RevealedTapscripts: tapscripts,
+			},
+		},
+		[]*wire.TxOut{
+			{
+				Value:    int64(vtxo.Amount),
+				PkScript: outScript,
+			},
+		},
+		checkpointTapscript,
+	)
+	require.NoError(t, err)
+
+	encodedCheckpoints := make([]string, 0, len(checkpointsPtx))
+	for _, checkpoint := range checkpointsPtx {
+		encoded, err := checkpoint.B64Encode()
+		require.NoError(t, err)
+		encodedCheckpoints = append(encodedCheckpoints, encoded)
+	}
+
+	encodedArkTx, err := ptx.B64Encode()
+	require.NoError(t, err)
+
+	signingKeys, err := handler.GetKeyRefs(ctr)
+	require.NoError(t, err)
+	require.NotEmpty(t, signingKeys)
+
+	signedArkTx, err := aliceWallet.SignTransaction(ctx, encodedArkTx, signingKeys)
+	require.NoError(t, err)
+
+	txid, _, _, err := arkClient.SubmitTx(ctx, signedArkTx, encodedCheckpoints)
+	require.NoError(t, err)
+	require.NotEmpty(t, txid)
+
+	return txid
 }
 
 // TestConcurrentTxs exercises the txHandler priority queue

--- a/wallet.go
+++ b/wallet.go
@@ -1344,6 +1344,15 @@ func (w *wallet) periodicRefreshDb(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			// Finalize any pending txs stranded by a send that was interrupted
+			// after the server registered the spend (e.g. a transient failure
+			// between SubmitTx and FinalizeTx). Otherwise the spent input stays
+			// spendable in the local db and coin selection keeps re-picking it
+			// until the next unlock. Best-effort, mirroring the unlock path; the
+			// refreshDb below (and the next tick) reconcile the finalized spend.
+			if _, err := w.finalizePendingTxs(ctx, nil); err != nil {
+				log.WithError(err).Warn("failed to finalize pending txs")
+			}
 			log.Debugf("refreshing db (last update %s)...", w.lastUpdate.Format(time.RFC3339))
 			if err := w.refreshDb(ctx); err != nil {
 				log.WithError(err).Error("failed to refresh db")


### PR DESCRIPTION
If a send is interrupted after `SubmitTx` has registered the spend but before `FinalizeTx` — a transient network error, a 502 from a proxy in front of the server — the input ends up spent server-side by an unfinalized ark tx while the local db still has it as spendable. Coin selection then keeps re-picking that input and every send fails with `VTXO_ALREADY_SPENT`.

Today `finalizePendingTxs` only runs at unlock, so a wallet that stays up never recovers on its own — we hit this downstream in fulmine, where a node failed every send for a few hours until it was restarted. This moves the same best-effort `finalizePendingTxs` call into `periodicRefreshDb` so it runs on each tick too, right before the refresh, matching what unlock already does. When nothing is pending it's a no-op beyond one indexer lookup.

I kept it best-effort (log and continue) to match the unlock path, and didn't add the `time.Sleep` init.go has after finalize — the refresh right after, plus the next tick, reconcile the finalized spend, so the periodic loop needn't block. The `GetPendingTx`/finalize loop in client-lib is already chunked at 20 inputs per intent, so the periodic call inherits that batching. Happy to fold the wait in or adjust placement if you'd prefer.

The e2e test mirrors the existing "finalize pending tx (auto)" case but, instead of restoring the wallet to trigger finalization, leaves the same client running and asserts the periodic refresh finalizes the stranded tx with no restart.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pending transactions can now be finalized automatically during periodic wallet refresh, even without a restart or restore.
  * This helps stranded transactions appear in transaction history once refresh completes.
  * Improved shutdown handling to best-effort finalize any remaining pending transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->