### PR TITLE
init.go: set dust on Unlock

### DIFF
--- a/init.go
+++ b/init.go
@@ -96,6 +96,12 @@ func (w *wallet) Unlock(ctx context.Context, password string) error {
 		return err
 	}
 
+	info, err := w.Client().GetInfo(ctx)
+	if err != nil {
+		return err
+	}
+	w.dustAmount = info.Dust
+
 	w.logMu.Lock()
 	log.SetLevel(log.DebugLevel)
 	if !w.verbose {

--- a/init.go
+++ b/init.go
@@ -2,6 +2,7 @@ package arksdk
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sort"
@@ -9,6 +10,7 @@ import (
 
 	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
 	clientwallet "github.com/arkade-os/arkd/pkg/client-lib"
+	"github.com/arkade-os/arkd/pkg/client-lib/client"
 	grpcclient "github.com/arkade-os/arkd/pkg/client-lib/client/grpc"
 	mempoolexplorer "github.com/arkade-os/arkd/pkg/client-lib/explorer/mempool"
 	"github.com/arkade-os/go-sdk/contract"
@@ -96,11 +98,10 @@ func (w *wallet) Unlock(ctx context.Context, password string) error {
 		return err
 	}
 
-	info, err := w.Client().GetInfo(ctx)
+	cfgData, err := w.client.GetConfigData(ctx)
 	if err != nil {
 		return err
 	}
-	w.dustAmount = info.Dust
 
 	w.logMu.Lock()
 	log.SetLevel(log.DebugLevel)
@@ -130,6 +131,25 @@ func (w *wallet) Unlock(ctx context.Context, password string) error {
 		return fmt.Errorf("failed to init contract manager: %w", err)
 	}
 
+	deprecatedSigners := make([]client.DeprecatedSigner, 0, len(cfgData.DeprecatedSigners))
+	for _, signer := range cfgData.DeprecatedSigners {
+		var cutoff int64
+		if !signer.CutoffDate.IsZero() {
+			cutoff = signer.CutoffDate.Unix()
+		}
+		deprecatedSigners = append(deprecatedSigners, client.DeprecatedSigner{
+			PubKey:     hex.EncodeToString(signer.PubKey.SerializeCompressed()),
+			CutoffDate: cutoff,
+		})
+	}
+	serverParams := &client.Info{
+		SignerPubKey:            hex.EncodeToString(cfgData.SignerPubKey.SerializeCompressed()),
+		DeprecatedSignerPubKeys: deprecatedSigners,
+	}
+
+	w.dustAmount = cfgData.Dust
+	w.network = cfgData.Network
+	w.lastSignerSet = signerSet(serverParams)
 	w.contractManager = mgr
 	w.resetSyncStateForUnlock()
 	w.utxoBroadcaster = newBroadcaster[types.UtxoEvent]()


### PR DESCRIPTION
it closes #206 

@sekulicd @altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet unlock reliability by updating wallet details immediately after a successful unlock, ensuring settings stay in sync with the latest configuration.
  * Refreshed wallet state values (including dust threshold and network/signer set metadata) from the server-provided data to reduce balance and signer-related inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->