### PR TITLE
Bump Go builder images to 1.26.5 to fix regtest builds

### DIFF
--- a/swap/swap.go
+++ b/swap/swap.go
@@ -1228,6 +1228,7 @@ func (h *SwapHandler) reverseSwap(
 		return nil, err
 	}
 
+	bgCtx := context.WithoutCancel(ctx)
 	go func(swapDetails Swap) {
 		if reedeemTxId, err := h.waitAndClaim(
 			invoiceExpiry, swapDetails.Id, preimage, vhtlcOpts,
@@ -1239,7 +1240,7 @@ func (h *SwapHandler) reverseSwap(
 			swapDetails.Status = SwapSuccess
 		}
 
-		if err := h.updatePersistedSwap(context.Background(), swapDetails); err != nil {
+		if err := h.updatePersistedSwap(bgCtx, swapDetails); err != nil {
 			log.WithError(err).Error("failed to update persisted reverse swap")
 		}
 

--- a/test/docker/emulator.Dockerfile
+++ b/test/docker/emulator.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4 AS builder
+FROM golang:1.26.5 AS builder
 
 ARG EMULATOR_VERSION=master
 

--- a/test/docker/fulmine.Dockerfile
+++ b/test/docker/fulmine.Dockerfile
@@ -5,7 +5,7 @@ RUN git clone --branch ${FULMINE_VERSION} --single-branch https://github.com/Ark
 WORKDIR /app/fulmine/internal/interface/web
 RUN rm -rf .parcel-cache && yarn && yarn build
 
-FROM golang:1.26.3 AS go-builder
+FROM golang:1.26.5 AS go-builder
 ARG FULMINE_VERSION=master
 ARG TARGETOS
 ARG TARGETARCH

--- a/test/docker/server.Dockerfile
+++ b/test/docker/server.Dockerfile
@@ -1,5 +1,5 @@
 # First image used to build the sources
-FROM golang:1.26.4 AS builder
+FROM golang:1.26.5 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/test/docker/wallet.Dockerfile
+++ b/test/docker/wallet.Dockerfile
@@ -1,5 +1,5 @@
 # First stage: build the ark-wallet-daemon binary
-FROM golang:1.26.4 AS builder
+FROM golang:1.26.5 AS builder
 
 ARG VERSION
 ARG TARGETOS


### PR DESCRIPTION
Running `make regtest` currently fails while building the emulator image, and the arkd and wallet images are broken the same way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environments to use Go 1.26.5 across emulator, Fulmine, server, and wallet container images.
  * No changes were made to application behavior or runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->