### PR TITLE
fix: stop busy-spinning on closed channels in wallet listeners

### DIFF
--- a/wallet.go
+++ b/wallet.go
@@ -934,7 +934,12 @@ func (w *wallet) listenForArkTxs(ctx context.Context) {
 			return
 		case event, ok := <-eventChan:
 			if !ok {
-				continue
+				// The transport retries with backoff on its own and closes the
+				// channel only on context cancelation or a terminal error, so
+				// there is nothing left to receive. Looping here would spin on
+				// a closed channel and peg a CPU core.
+				log.Warn("ark tx stream closed, stopping ark tx listener")
+				return
 			}
 			if errors.Is(event.Err, io.EOF) {
 				closeFunc()
@@ -1283,6 +1288,13 @@ func (w *wallet) listenForOnchainTxs(ctx context.Context, network arklib.Network
 }
 
 func (w *wallet) listenDbEvents(ctx context.Context) {
+	// Held in locals so a closed channel can be dropped from the select below.
+	// Receiving from a closed channel returns immediately and forever, so an
+	// arm that is not removed would spin the loop and peg a CPU core.
+	utxoCh := w.store.UtxoStore().GetEventChannel()
+	vtxoCh := w.store.VtxoStore().GetEventChannel()
+	txCh := w.store.TransactionStore().GetEventChannel()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -1297,8 +1309,10 @@ func (w *wallet) listenDbEvents(ctx context.Context) {
 				w.txBroadcaster.close()
 			}
 			return
-		case event, ok := <-w.store.UtxoStore().GetEventChannel():
+		case event, ok := <-utxoCh:
 			if !ok {
+				// A nil channel blocks forever, removing this arm.
+				utxoCh = nil
 				continue
 			}
 			go func() {
@@ -1310,8 +1324,9 @@ func (w *wallet) listenDbEvents(ctx context.Context) {
 					)
 				}
 			}()
-		case event, ok := <-w.store.VtxoStore().GetEventChannel():
+		case event, ok := <-vtxoCh:
 			if !ok {
+				vtxoCh = nil
 				continue
 			}
 			go func() {
@@ -1323,8 +1338,9 @@ func (w *wallet) listenDbEvents(ctx context.Context) {
 					)
 				}
 			}()
-		case event, ok := <-w.store.TransactionStore().GetEventChannel():
+		case event, ok := <-txCh:
 			if !ok {
+				txCh = nil
 				continue
 			}
 			go func() {

--- a/wallet_listeners_cpu_internal_test.go
+++ b/wallet_listeners_cpu_internal_test.go
@@ -1,0 +1,121 @@
+//go:build unix
+
+package arksdk
+
+import (
+	"context"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/arkade-os/go-sdk/types"
+)
+
+// stubUtxoStore, stubVtxoStore and stubTxStore each expose one test-owned event
+// channel. Every other store method is nil and panics if called.
+type stubUtxoStore struct {
+	types.UtxoStore
+	ch <-chan types.UtxoEvent
+}
+
+func (s *stubUtxoStore) GetEventChannel() <-chan types.UtxoEvent { return s.ch }
+
+type stubVtxoStore struct {
+	types.VtxoStore
+	ch <-chan types.VtxoEvent
+}
+
+func (s *stubVtxoStore) GetEventChannel() <-chan types.VtxoEvent { return s.ch }
+
+type stubTxStore struct {
+	types.TransactionStore
+	ch <-chan types.TransactionEvent
+}
+
+func (s *stubTxStore) GetEventChannel() <-chan types.TransactionEvent { return s.ch }
+
+type stubEventStore struct {
+	types.Store
+	utxo *stubUtxoStore
+	vtxo *stubVtxoStore
+	tx   *stubTxStore
+}
+
+func (s *stubEventStore) UtxoStore() types.UtxoStore               { return s.utxo }
+func (s *stubEventStore) VtxoStore() types.VtxoStore               { return s.vtxo }
+func (s *stubEventStore) TransactionStore() types.TransactionStore { return s.tx }
+
+// processCPU reports CPU time consumed by this process so far. A parked
+// goroutine adds essentially none; a busy-spinning one adds roughly wall-clock.
+func processCPU(t *testing.T) time.Duration {
+	t.Helper()
+	var ru syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &ru); err != nil {
+		t.Fatalf("getrusage: %v", err)
+	}
+	return time.Duration(ru.Utime.Nano() + ru.Stime.Nano())
+}
+
+const (
+	// cpuSampleWindow is how long the listener is observed while idle.
+	cpuSampleWindow = 300 * time.Millisecond
+	// cpuSpinThreshold is the budget for that window. A parked listener uses
+	// microseconds and a spinning one uses the full window, so anything in
+	// between is a comfortable margin either way.
+	cpuSpinThreshold = 100 * time.Millisecond
+)
+
+// TestListenDbEventsDoesNotSpinOnClosedChannels pins the fix for a busy-spin in
+// the db event loop. It selects over three store channels at once, so a closed
+// channel cannot simply end the loop; the closed arm has to be dropped from the
+// select instead, or receiving from it returns immediately and forever.
+func TestListenDbEventsDoesNotSpinOnClosedChannels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	utxoCh := make(chan types.UtxoEvent)
+	vtxoCh := make(chan types.VtxoEvent)
+	txCh := make(chan types.TransactionEvent)
+
+	w := &wallet{
+		store: &stubEventStore{
+			utxo: &stubUtxoStore{ch: utxoCh},
+			vtxo: &stubVtxoStore{ch: vtxoCh},
+			tx:   &stubTxStore{ch: txCh},
+		},
+		utxoBroadcaster: newBroadcaster[types.UtxoEvent](),
+		vtxoBroadcaster: newBroadcaster[types.VtxoEvent](),
+		txBroadcaster:   newBroadcaster[types.TransactionEvent](),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.listenDbEvents(ctx)
+	}()
+
+	// Every source is gone, so the listener has nothing left to do but wait for
+	// cancelation. It must park, not spin.
+	close(utxoCh)
+	close(vtxoCh)
+	close(txCh)
+
+	before := processCPU(t)
+	time.Sleep(cpuSampleWindow)
+	used := processCPU(t) - before
+
+	if used > cpuSpinThreshold {
+		t.Fatalf(
+			"listenDbEvents burned %v of CPU in %v with all store channels closed: it is busy-spinning",
+			used,
+			cpuSampleWindow,
+		)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(listenerReturnTimeout):
+		t.Fatal("listenDbEvents did not return after its context was canceled")
+	}
+}

--- a/wallet_listeners_internal_test.go
+++ b/wallet_listeners_internal_test.go
@@ -1,0 +1,72 @@
+package arksdk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clientwallet "github.com/arkade-os/arkd/pkg/client-lib"
+	"github.com/arkade-os/arkd/pkg/client-lib/client"
+	"github.com/arkade-os/arkd/pkg/client-lib/identity"
+)
+
+// listenerReturnTimeout bounds how long a listener may take to notice that its
+// source channel is gone. A busy-spinning listener never returns, so it trips
+// this instead of hanging the suite forever.
+const listenerReturnTimeout = 2 * time.Second
+
+// stubIdentity satisfies identity.Identity by embedding it. The listener only
+// checks the value for nil, so no method is ever called.
+type stubIdentity struct{ identity.Identity }
+
+// stubStreamWallet stubs the two clientwallet.Wallet methods listenForArkTxs
+// reads. Every other method is nil and panics if called.
+type stubStreamWallet struct {
+	clientwallet.Wallet
+	client client.Client
+}
+
+func (s *stubStreamWallet) Identity() identity.Identity { return &stubIdentity{} }
+func (s *stubStreamWallet) Client() client.Client       { return s.client }
+
+// stubStreamClient hands out a transaction stream the test owns, so the test
+// can close it and observe how the listener reacts.
+type stubStreamClient struct {
+	client.Client
+	ch <-chan client.TransactionEvent
+}
+
+func (s *stubStreamClient) GetTransactionsStream(
+	_ context.Context,
+) (<-chan client.TransactionEvent, func(), error) {
+	return s.ch, func() {}, nil
+}
+
+// TestListenForArkTxsStopsWhenStreamCloses pins the fix for a busy-spin that
+// pegged a full CPU core: receiving from a closed channel returns immediately
+// and forever, so a `continue` on !ok re-enters the select with nothing left to
+// block on. The transport reconnects internally and only closes the channel on
+// a terminal error, so the listener must stop rather than loop.
+func TestListenForArkTxsStopsWhenStreamCloses(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan client.TransactionEvent)
+	w := &wallet{
+		client: &stubStreamWallet{client: &stubStreamClient{ch: ch}},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.listenForArkTxs(ctx)
+	}()
+
+	close(ch)
+
+	select {
+	case <-done:
+	case <-time.After(listenerReturnTimeout):
+		t.Fatal("listenForArkTxs did not return after its stream closed: it is busy-spinning")
+	}
+}


### PR DESCRIPTION
Looking at the container stats on `mutinynet` indicates that the the Fulmine delegator constantly consumes 100% CPU. My investigation through the code with Claude indicated some goroutine spin loops in the SDK:

> The transport already reconnects forever. client-lib's StartReconnectingStream retries with backoff in an inner loop with no attempt cap. It closes eventsCh (via defer close) in only three cases: context cancellation, a non-retryable Recv error, or a non-retryable dial error. The last two call sendTerminalErr first — pushing an error event — and then close.
>
> That reproduces your exact log signature: a terminal error event arrives (listener logs it at Warn and continues), then the channel closes and the listener spins forever. The Warn happened ~28 days ago and has long since rotated out of your --tail 40.
>
> So a closed channel is terminal and permanent — reconnection is the transport's job and it has definitively given up. That settles the fix direction for listenForArkTxs: return, exactly like the existing io.EOF path directly below it.
>
> The other three sites need a different fix. listenDbEvents (wallet.go:1301/1314/1327) selects over three store channels at once, so return would abandon the two healthy ones. The Go idiom there is to nil out the closed channel — a nil channel blocks forever, removing that arm from the select — which requires hoisting the three GetEventChannel() calls into locals first. I checked: those return stable struct fields, so hoisting is safe.

listenForArkTxs looped on `continue` when its transaction stream channel closed. Receiving from a closed channel returns immediately and forever, so the select had nothing left to block on and pegged a full CPU core. The transport reconnects internally with backoff and closes the channel only on context cancelation or a terminal error, so the listener now returns.

listenDbEvents had the same defect across its three store channels. It cannot simply return, since the arms are independent, so each closed channel is now set to nil to drop it from the select.

Both paths are covered by regression tests: one asserts the ark tx listener returns when its stream closes, the other asserts the db event loop consumes no CPU once all three store channels are closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wallet event listeners continuing to consume CPU after transaction or store event streams close.
  * Improved listener shutdown behavior when event channels are closed.

* **Tests**
  * Added regression coverage to verify listeners stop promptly and avoid excessive CPU usage after stream closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->