### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Disclosures
 
-Security is a top priority for Ark. If you discover a security issue, please bring it to our attention right away. Please DO NOT file a public issue, instead send your report privately by sending an email to <security@arklabs.to>.
+Security is a top priority for Ark Labs. If you discover a security issue, please bring it to our attention right away. Please DO NOT file a public issue, instead send your report privately by sending an email to <security@arklabs.to>.
 
 Security reports are greatly appreciated and we will publicly thank you for it.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Disclosures
+
+Security is a top priority for Ark. If you discover a security issue, please bring it to our attention right away. Please DO NOT file a public issue, instead send your report privately by sending an email to <security@arklabs.to>.
+
+Security reports are greatly appreciated and we will publicly thank you for it.
+
+The following keys may be used to communicate sensitive information to developers:
+
+| Name | PGP Public Key URL | Fingerprint |
+|------|-------------|-------------|
+| Marco Argentieri | [https://github.com/tiero.gpg](https://github.com/tiero.gpg) | 0F6586CE8DA12FB1 |
+| Pietralberto Mazza | [https://github.com/altafan.gpg](https://github.com/altafan.gpg) | 6C7639DEA147673B |
+| Andrew Camilleri | [https://github.com/Kukks.gpg](https://github.com/Kukks.gpg) | F918A46E23064E28 |
+
+You can import a key by running the following command in your terminal and verify the fingerprint matches the one above:
+
+```bash
+gpg --fetch-keys <PGP Public Key URL>
+```


### PR DESCRIPTION
Adds the security disclosure policy, copied from the `arkd` repo, with the nostr DM contact removed — reports go to <security@arklabs.to>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ek8iDTwb1V7PVh1kKewSVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ek8iDTwb1V7PVh1kKewSVg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security reporting guidance, including private contact instructions and expected acknowledgment.
  * Added developer PGP public key links, fingerprints, and import instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->