### PR TITLE
swap: claim the vtxo boltz's lockup tx created

### DIFF
--- a/swap/chainswap_btc_ark_handler.go
+++ b/swap/chainswap_btc_ark_handler.go
@@ -122,13 +122,22 @@ func (b *btcToArkHandler) handleBtcToArkServerLocked(
 	serverLockupTxID := update.Transaction.Id
 	b.chainSwapState.Swap.ServerLock(serverLockupTxID)
 
+	// Claim the vtxo that boltz's lockup tx created, rather than whichever one
+	// sorts first by age at this address.
+	outpoint, err := b.swapHandler.outpointForFundingTx(
+		ctx, b.chainSwapState.Swap.VhtlcOpts, serverLockupTxID,
+	)
+	if err != nil {
+		b.chainSwapState.Swap.Fail(fmt.Sprintf("claim failed: %v", err))
+		return fmt.Errorf("failed to resolve Ark VTXO for lockup tx %s: %w", serverLockupTxID, err)
+	}
+
 	// Claim Ark VTXOs lockup
-	//TODO check if we should pass outpoint similarly as in swap
 	claimTxid, err := b.swapHandler.ClaimVHTLC(
 		ctx,
 		b.preimage,
 		b.chainSwapState.Swap.VhtlcOpts,
-		nil,
+		outpoint,
 	)
 	if err != nil {
 		// ChainSwap.Fail() emits FailEvent automatically

--- a/swap/chainswap_btc_ark_handler.go
+++ b/swap/chainswap_btc_ark_handler.go
@@ -124,6 +124,14 @@ func (b *btcToArkHandler) handleBtcToArkServerLocked(
 
 	// Claim the vtxo that boltz's lockup tx created, rather than whichever one
 	// sorts first by age at this address.
+	//
+	// This fires on the mempool event, so the vtxo may not be indexed yet and
+	// resolution can report ErrorNoVtxosFound. There is no retry here and the
+	// swap fails, which is the behaviour that was already in place: claiming
+	// with a nil outpoint reached the same error from selectClaimableVTXO when
+	// nothing was at the address. If that timing window turns out to be real in
+	// practice, the fix is a bounded retry around both calls, not a silent
+	// fallback to picking some other vtxo.
 	outpoint, err := b.swapHandler.outpointForFundingTx(
 		ctx, b.chainSwapState.Swap.VhtlcOpts, serverLockupTxID,
 	)

--- a/swap/funding_outpoint_test.go
+++ b/swap/funding_outpoint_test.go
@@ -1,0 +1,96 @@
+package swap
+
+import (
+	"testing"
+
+	clientTypes "github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/stretchr/testify/require"
+)
+
+func vtxoAt(txid string, vout uint32) clientTypes.Vtxo {
+	return clientTypes.Vtxo{
+		Outpoint: clientTypes.Outpoint{Txid: txid, VOut: vout},
+	}
+}
+
+func TestSelectOutpointByFundingTxid(t *testing.T) {
+	const funding = "aa11"
+	const other = "bb22"
+
+	t.Run("no funding txid leaves selection unchanged", func(t *testing.T) {
+		outpoint, err := selectOutpointByFundingTxid(
+			[]clientTypes.Vtxo{vtxoAt(other, 0)}, nil, "",
+		)
+		require.NoError(t, err)
+		require.Nil(t, outpoint)
+	})
+
+	// Reporting ErrorNoVtxosFound rather than a nil outpoint is what keeps the
+	// reverse swap waiting for the funding vtxo instead of falling back to
+	// whatever else is already sitting at the address.
+	t.Run("unmatched funding txid reports no vtxos found", func(t *testing.T) {
+		outpoint, err := selectOutpointByFundingTxid(
+			[]clientTypes.Vtxo{vtxoAt(other, 0), vtxoAt("cc33", 1)}, nil, funding,
+		)
+		require.ErrorIs(t, err, ErrorNoVtxosFound)
+		require.Nil(t, outpoint)
+	})
+
+	t.Run("no vtxos at all reports no vtxos found", func(t *testing.T) {
+		outpoint, err := selectOutpointByFundingTxid(nil, nil, funding)
+		require.ErrorIs(t, err, ErrorNoVtxosFound)
+		require.Nil(t, outpoint)
+	})
+
+	t.Run("picks the funding vtxo over an older decoy", func(t *testing.T) {
+		outpoint, err := selectOutpointByFundingTxid(
+			[]clientTypes.Vtxo{vtxoAt(other, 0), vtxoAt(funding, 3)}, nil, funding,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, outpoint)
+		require.Equal(t, clientTypes.Outpoint{Txid: funding, VOut: 3}, *outpoint)
+	})
+
+	t.Run("finds the funding vtxo among pending", func(t *testing.T) {
+		outpoint, err := selectOutpointByFundingTxid(
+			[]clientTypes.Vtxo{vtxoAt(other, 0)},
+			[]clientTypes.Vtxo{vtxoAt(funding, 1)},
+			funding,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, outpoint)
+		require.Equal(t, clientTypes.Outpoint{Txid: funding, VOut: 1}, *outpoint)
+	})
+
+	// A vtxo may be reported as both spendable and pending. That is the same
+	// candidate twice, not two competing outputs.
+	t.Run("same outpoint in both lists is one candidate", func(t *testing.T) {
+		same := vtxoAt(funding, 2)
+		outpoint, err := selectOutpointByFundingTxid(
+			[]clientTypes.Vtxo{same}, []clientTypes.Vtxo{same}, funding,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, outpoint)
+		require.Equal(t, clientTypes.Outpoint{Txid: funding, VOut: 2}, *outpoint)
+	})
+
+	// One transaction paying the address twice gives no basis to choose, so it
+	// is reported rather than resolved.
+	t.Run("two outputs of the funding tx are ambiguous", func(t *testing.T) {
+		outpoint, err := selectOutpointByFundingTxid(
+			[]clientTypes.Vtxo{vtxoAt(funding, 0), vtxoAt(funding, 1)}, nil, funding,
+		)
+		require.ErrorContains(t, err, "several outputs")
+		require.Nil(t, outpoint)
+	})
+
+	t.Run("ambiguity is detected across the two lists", func(t *testing.T) {
+		outpoint, err := selectOutpointByFundingTxid(
+			[]clientTypes.Vtxo{vtxoAt(funding, 0)},
+			[]clientTypes.Vtxo{vtxoAt(funding, 1)},
+			funding,
+		)
+		require.ErrorContains(t, err, "several outputs")
+		require.Nil(t, outpoint)
+	})
+}

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -1342,10 +1342,21 @@ func (h *SwapHandler) waitAndClaim(
 			}
 			if confirmed {
 				interval := 200 * time.Millisecond
+				fundingTxid := update.Transaction.Id
 				log.Debug("claiming VHTLC with preimage...")
 				if err := retry(ctx, interval, func(ctx context.Context) (bool, error) {
-					var err error
-					txid, err = h.ClaimVHTLC(ctx, preimage, vhtlcOpts, nil)
+					// Resolved inside the retry: until the funding vtxo shows
+					// up this reports ErrorNoVtxosFound, which keeps waiting
+					// rather than claiming whatever else is at the address.
+					outpoint, err := h.outpointForFundingTx(ctx, vhtlcOpts, fundingTxid)
+					if err != nil {
+						if errors.Is(err, ErrorNoVtxosFound) {
+							return false, nil
+						}
+						return false, err
+					}
+
+					txid, err = h.ClaimVHTLC(ctx, preimage, vhtlcOpts, outpoint)
 					if err != nil {
 						if errors.Is(err, ErrorNoVtxosFound) {
 							return false, nil
@@ -1443,6 +1454,76 @@ func (h *SwapHandler) getBatchSessionArgs(
 		signerSession:   *signerSession,
 		vtxos:           vtxoTapscripts,
 	}, nil
+}
+
+// outpointForFundingTx resolves the vtxo that fundingTxid created at the VHTLC
+// address. Boltz names the transaction that locked the funds, so a claim can
+// say which vtxo it means instead of falling back to creation order, which
+// picks by age and so prefers anything that arrived at the address earlier.
+//
+// An empty fundingTxid yields a nil outpoint, leaving selection unchanged. A
+// txid that matches nothing yet yields ErrorNoVtxosFound rather than a nil
+// outpoint, so callers that retry on that error wait for the funding vtxo to
+// appear instead of claiming whatever else is already sitting there.
+func (h *SwapHandler) outpointForFundingTx(
+	ctx context.Context, vhtlcOpts vhtlc.Opts, fundingTxid string,
+) (*clientTypes.Outpoint, error) {
+	if fundingTxid == "" {
+		return nil, nil
+	}
+
+	vhtlcScript, err := vhtlc.NewVHTLCScriptFromOpts(vhtlcOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VHTLC script: %w", err)
+	}
+
+	spendableVtxos, err := h.getVHTLCFunds(ctx, []*vhtlc.VHTLCScript{vhtlcScript})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get spendable VHTLC funds: %w", err)
+	}
+	pendingVtxos, err := h.getPendingVHTLCFunds(ctx, []*vhtlc.VHTLCScript{vhtlcScript})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pending VHTLC funds: %w", err)
+	}
+
+	return selectOutpointByFundingTxid(spendableVtxos, pendingVtxos, fundingTxid)
+}
+
+// selectOutpointByFundingTxid picks the outpoint funded by fundingTxid out of
+// the vtxos held at a VHTLC address. Split out from outpointForFundingTx so the
+// selection can be exercised without standing up an indexer.
+//
+// A vtxo can appear in both lists, so the same outpoint seen twice is one
+// candidate, not a collision.
+func selectOutpointByFundingTxid(
+	spendableVtxos, pendingVtxos []clientTypes.Vtxo, fundingTxid string,
+) (*clientTypes.Outpoint, error) {
+	if fundingTxid == "" {
+		return nil, nil
+	}
+
+	var found *clientTypes.Outpoint
+	for _, vtxos := range [][]clientTypes.Vtxo{spendableVtxos, pendingVtxos} {
+		for _, vtxo := range vtxos {
+			if vtxo.Txid != fundingTxid {
+				continue
+			}
+			if found != nil && *found != vtxo.Outpoint {
+				// The same transaction paid this address more than once and
+				// nothing here says which output the swap is for.
+				return nil, fmt.Errorf(
+					"funding tx %s has several outputs for this VHTLC", fundingTxid,
+				)
+			}
+			outpoint := vtxo.Outpoint
+			found = &outpoint
+		}
+	}
+
+	if found == nil {
+		return nil, ErrorNoVtxosFound
+	}
+	return found, nil
 }
 
 func (h *SwapHandler) selectClaimableVTXO(

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -39,7 +39,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var ErrorNoVtxosFound = fmt.Errorf("no vtxos found for the given vhtlc opts")
+// ErrorNoVtxosFound is a sentinel, compared with errors.Is by the claim retry
+// paths. errors.New rather than fmt.Errorf to say so: a formatted construction
+// invites someone to add a %v of it later, which would produce a value that no
+// longer matches and would silently turn a retry into a failure.
+var ErrorNoVtxosFound = errors.New("no vtxos found for the given vhtlc opts")
 
 const boltzReconnectBackoff = time.Second
 


### PR DESCRIPTION
Both internal claim paths passed a nil outpoint to `selectClaimableVTXO`, so selection fell back to creation order. Ordering picks by age, which means anything that reached the VHTLC address before boltz funded it gets claimed first.

Boltz names the locking transaction in the update that triggers the claim, and both paths already have it — the chain swap handler reads it for `ServerLock`, the reverse swap loop ignores it. Resolve that txid to the vtxo it created and claim that one.

`outpointForFundingTx` returns:

| input | result |
|---|---|
| empty txid | nil outpoint, selection unchanged |
| txid matches one vtxo | that outpoint |
| txid matches nothing yet | `ErrorNoVtxosFound` |
| txid paid the address twice | error, nothing distinguishes the outputs |

The third row is the one to look at. Returning `ErrorNoVtxosFound` rather than a nil outpoint means the reverse swap keeps waiting for the funding vtxo instead of falling back to whatever is already at the address — which is why resolution happens *inside* the retry closure rather than before it. The chain swap handler has no retry and already fails when no vtxo is found, so its behaviour there is unchanged.

Also drops the `//TODO check if we should pass outpoint similarly as in swap` in the chain swap handler. The answer was yes, and the swap path wasn't doing it either.

## Test plan

`selectOutpointByFundingTxid` is split out from the indexer lookup so the selection can be tested directly. Eight cases: empty txid, no match, no vtxos at all, match in spendable, match in pending, the same outpoint reported in both lists, one tx paying the address twice, and ambiguity split across the two lists.

The both-lists case is the subtle one — a vtxo reported as both spendable and pending is one candidate, not competing outputs.

- `./swap/...`: ok, matching the pre-change baseline
- `go build ./...`, `go vet ./swap/...` clean
- gofmt clean

## Note

The same change landed in fulmine as ArkLabsHQ/fulmine#466, where the integration suite covers both paths end to end (`TestReverseSwap`, `TestChainSwapBTCtoARK`) and passes. This repo has no equivalent integration coverage for those flows, so the unit tests above are the gate here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap claims by selecting the precise funding output associated with each transaction.
  * Added retries when the matching output is temporarily unavailable.
  * Prevented claims from using unrelated or ambiguous funds.
  * Swaps now fail clearly when the required funding output cannot be identified.
  * Improved Bitcoin Ark swap claims by resolving the associated funding output before claiming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->